### PR TITLE
Allow Session#visit to visit absolute URLs with no scheme.

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -206,24 +206,30 @@ module Capybara
 
       @touched = true
 
-      url_relative = URI.parse(url.to_s).scheme.nil?
+      uri = URI.parse(url.to_s)
 
-      if url_relative && Capybara.app_host
-        url = Capybara.app_host + url.to_s
-        url_relative = false
+      if uri.host.nil? && Capybara.app_host
+        app_host_uri = URI.parse(Capybara.app_host)
+        uri.scheme = app_host_uri.scheme
+        uri.host   = app_host_uri.host
+        uri.port   = app_host_uri.port
       end
 
       if @server
-        url = "http://#{@server.host}:#{@server.port}" + url.to_s if url_relative
+        if uri.host.nil?
+          uri.host = @server.host
+          uri.port = @server.port
+        end
 
-        if Capybara.always_include_port
-          uri = URI.parse(url)
-          uri.port = @server.port if uri.port == uri.default_port
-          url = uri.to_s
+        if Capybara.always_include_port && uri.port == uri.default_port
+          uri.port = @server.port
         end
       end
 
-      driver.visit(url)
+      uri.scheme ||= 'http'
+      uri.path = '/' if uri.path.to_s.empty?
+
+      driver.visit(uri.to_s)
     end
 
     ##

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -208,27 +208,29 @@ module Capybara
 
       uri = URI.parse(url.to_s)
 
-      if uri.host.nil? && Capybara.app_host
-        app_host_uri = URI.parse(Capybara.app_host)
-        uri.scheme = app_host_uri.scheme
-        uri.host   = app_host_uri.host
-        uri.port   = app_host_uri.port
-      end
+      unless uri.registry || uri.opaque
 
-      if @server
-        if uri.host.nil?
-          uri.host = @server.host
-          uri.port = @server.port
+        if uri.host.nil? && Capybara.app_host
+          app_host_uri = URI.parse(Capybara.app_host)
+          uri.scheme = app_host_uri.scheme
+          uri.host   = app_host_uri.host
+          uri.port   = app_host_uri.port
         end
 
-        if Capybara.always_include_port && uri.port == uri.default_port
-          uri.port = @server.port
+        if @server
+          if uri.host.nil?
+            uri.host = @server.host
+            uri.port = @server.port
+          end
+
+          if Capybara.always_include_port && uri.port == uri.default_port
+            uri.port = @server.port
+          end
         end
+
+        uri.scheme ||= 'http'
+        uri.path = '/' if uri.path.to_s.empty?
       end
-
-      uri.scheme ||= 'http'
-      uri.path = '/' if uri.path.to_s.empty?
-
       driver.visit(uri.to_s)
     end
 

--- a/lib/capybara/spec/session/visit_spec.rb
+++ b/lib/capybara/spec/session/visit_spec.rb
@@ -17,6 +17,15 @@ Capybara::SpecHelper.spec '#visit' do
     expect(@session).to have_content('Another World')
   end
 
+  it "should fetch a response when absolute URI doesn't have a scheme" do
+    # Preparation
+    @session.visit('/')
+    root_uri = URI.parse(@session.current_url)
+
+    @session.visit("//#{root_uri.host}:#{root_uri.port}/")
+    expect(@session).to have_content('Hello world!')
+  end
+
   it "should fetch a response when absolute URI doesn't have a trailing slash" do
     # Preparation
     @session.visit('/foo/bar')
@@ -75,6 +84,12 @@ Capybara::SpecHelper.spec '#visit' do
     it "should visit a fully qualified URL" do
       serverless_session = Capybara::Session.new(@session.mode, nil)
       serverless_session.visit("http://#{@session.server.host}:#{@session.server.port}/foo")
+      expect(serverless_session).to have_content("Another World")
+    end
+
+    it "should visit an absolute URL without scheme" do
+      serverless_session = Capybara::Session.new(@session.mode, nil)
+      serverless_session.visit("//#{@session.server.host}:#{@session.server.port}/foo")
       expect(serverless_session).to have_content("Another World")
     end
   end


### PR DESCRIPTION
Hello,

Looking at [the code](https://github.com/jnicklas/capybara/blob/master/lib/capybara/session.rb#L209), it looks like Capybara considers any URL without scheme to be relative.
Actually, an absolute URL can have an empty scheme: when encountering `//example.com`, browsers will use the same scheme as the current page (thus https://example.com if you're currently on an HTTPS page, or http://example.com otherwise).

Please find my suggestions in this pull request.

Regards,

David