### PR TITLE
add method current_path_query to Capybara::Session

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -43,12 +43,12 @@ module Capybara
     ]
     SESSION_METHODS = [
       :body, :html, :source, :current_url, :current_host, :current_path,
-      :execute_script, :evaluate_script, :visit, :go_back, :go_forward,
-      :within, :within_fieldset, :within_table, :within_frame, :current_window,
-      :windows, :open_new_window, :switch_to_window, :within_window, :window_opened_by,
-      :save_page, :save_and_open_page, :save_screenshot,
-      :save_and_open_screenshot, :reset_session!, :response_headers,
-      :status_code, :current_scope
+      :current_path_query, :execute_script, :evaluate_script, :visit, :go_back,
+      :go_forward, :within, :within_fieldset, :within_table, :within_frame,
+      :current_window, :windows, :open_new_window, :switch_to_window,
+      :within_window, :window_opened_by, :save_page, :save_and_open_page,
+      :save_screenshot, :save_and_open_screenshot, :reset_session!,
+      :response_headers, :status_code, :current_scope
     ] + DOCUMENT_METHODS
     MODAL_METHODS = [
       :accept_alert, :accept_confirm, :dismiss_confirm, :accept_prompt,
@@ -173,6 +173,16 @@ module Capybara
     #
     def current_url
       driver.current_url
+    end
+
+    ##
+    #
+    # @return [String] Path and query of the current page, without any domain information
+    #
+    def current_path_query
+      uri = URI.parse(current_url)
+      return current_path if (not uri.query) or (uri.query and uri.query.empty?)
+      return "#{uri.path}?#{uri.query}" if uri.path and not uri.path.empty?
     end
 
     ##

--- a/lib/capybara/spec/session/current_url_spec.rb
+++ b/lib/capybara/spec/session/current_url_spec.rb
@@ -1,4 +1,4 @@
-Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
+Capybara::SpecHelper.spec '#current_url, #current_path, #current_host, #current_path_query' do
   before :all do
     @servers = 2.times.map { Capybara::Server.new(TestApp.clone).boot }
     # sanity check
@@ -10,12 +10,18 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
     @servers.map { |s| "http://#{s.host}:#{s.port}" }
   end
 
-  def should_be_on server_index, path="/host", scheme="http"
+  def should_be_on server_index, path="/host", query="query=test", scheme="http"
     # Check that we are on /host on the given server
     s = @servers[server_index]
-    expect(@session.current_url.chomp('?')).to eq("#{scheme}://#{s.host}:#{s.port}#{path}")
     expect(@session.current_host).to eq("#{scheme}://#{s.host}") # no port
     expect(@session.current_path).to eq(path)
+    if query.empty?
+      expect(@session.current_url.chomp('?')).to eq("#{scheme}://#{s.host}:#{s.port}#{path}")
+      expect(@session.current_path_query).to eq(path)
+    else
+      expect(@session.current_url.chomp('?')).to eq("#{scheme}://#{s.host}:#{s.port}#{path}?#{query}")
+      expect(@session.current_path_query).to include(path, query)
+    end
     if path == '/host'
       # Server should agree with us
       expect(@session).to have_content("Current host is #{scheme}://#{s.host}:#{s.port}")
@@ -23,29 +29,29 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
   end
 
   def visit_host_links
-    @session.visit("#{bases[0]}/host_links?absolute_host=#{bases[1]}")
+    @session.visit("#{bases[0]}/host_links?absolute_host=#{bases[1]}&query=test")
   end
 
   it "is affected by visiting a page directly" do
-    @session.visit("#{bases[0]}/host")
+    @session.visit("#{bases[0]}/host?query=test")
     should_be_on 0
   end
 
   it "returns to the app host when visiting a relative url" do
     Capybara.app_host = bases[1]
-    @session.visit("#{bases[0]}/host")
+    @session.visit("#{bases[0]}/host?query=test")
     should_be_on 0
-    @session.visit('/host')
+    @session.visit('/host?query=test')
     should_be_on 1
     Capybara.app_host = nil
   end
 
   it "is affected by setting Capybara.app_host" do
     Capybara.app_host = bases[0]
-    @session.visit("/host")
+    @session.visit("/host?query=test")
     should_be_on 0
     Capybara.app_host = bases[1]
-    @session.visit("/host")
+    @session.visit("/host?query=test")
     should_be_on 1
     Capybara.app_host = nil
   end
@@ -53,41 +59,43 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
   it "is unaffected by following a relative link" do
     visit_host_links
     @session.click_link("Relative Host")
-    should_be_on 0
+    should_be_on 0, "/host", ""
   end
 
   it "is affected by following an absolute link" do
     visit_host_links
     @session.click_link("Absolute Host")
-    should_be_on 1
+    should_be_on 1, "/host", ""
   end
 
   it "is unaffected by posting through a relative form" do
     visit_host_links
     @session.click_button("Relative Host")
-    should_be_on 0
+    should_be_on 0, "/host", ""
   end
 
   it "is affected by posting through an absolute form" do
     visit_host_links
     @session.click_button("Absolute Host")
-    should_be_on 1
+    should_be_on 1, "/host", ""
   end
 
   it "is affected by following a redirect" do
     @session.visit("#{bases[0]}/redirect")
-    should_be_on 0, "/landed"
+    should_be_on 0, "/landed", ""
   end
 
   it "is affected by pushState", :requires => [:js] do
     @session.visit("/with_js")
-    @session.execute_script("window.history.pushState({}, '', '/pushed')")
+    @session.execute_script("window.history.pushState({}, '', '/pushed?query=test')")
     expect(@session.current_path).to eq("/pushed")
+    expect(@session.current_path_query).to eq("/pushed?query=test")
   end
 
   it "is affected by replaceState", :requires => [:js] do
     @session.visit("/with_js")
-    @session.execute_script("window.history.replaceState({}, '', '/replaced')")
+    @session.execute_script("window.history.replaceState({}, '', '/replaced?query=test')")
     expect(@session.current_path).to eq("/replaced")
+    expect(@session.current_path_query).to eq("/replaced?query=test")
   end
 end


### PR DESCRIPTION
current_path_query is a method that return Path and query of the current page without any domain information