### PR TITLE
Update Readme instructions for Test::Unit and Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ end
     class ActionDispatch::IntegrationTest
       # Make the Capybara DSL available in all integration tests
       include Capybara::DSL
+
+      # Reset sessions and driver between tests
+      # Use super wherever this method is redefined in your individual test classes
+      def teardown
+        Capybara.reset_sessions!
+        Capybara.use_default_driver
+      end
     end
     ```
 


### PR DESCRIPTION
The readme makes it look/sound like that if you're using Test::Unit (or Minitest::Spec) with Rails, there's no need to add the `teardown` method given in the non-Rails snippet. However if you don't, the session and driver state will be retained between tests, which is different to the behaviour that Rspec gets by default, and obviously breaks test isolation. This PR attempts to reduce confusion that may arise (which is what happened in my case).

Ideally, I think Test::Unit / Minitest should get this behaviour by default just like Rspec does, perhaps through the [`after_teardown`](http://docs.seattlerb.org/minitest/Minitest/Test/LifecycleHooks.html#method-i-after_teardown) callback Minitest provides?