### PR TITLE
Contribution to the README for Capybara + database_cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ your test code to be invisible to Capybara.
 Cucumber handles this by using truncation instead of transactions, i.e. they
 empty out the entire database after each test. You can get the same behaviour
 by using a gem such as [database_cleaner](https://github.com/bmabey/database_cleaner).
+[This post](http://devblog.avdi.org/2012/08/31/configuring-database_cleaner-with-rails-rspec-capybara-and-selenium/#comment-1550901866) shows how to setup database_cleaner for use with Capybara.
 
 It is also possible to force your ORM to use the same transaction for all
 threads.  This may have thread safety implications and could cause strange


### PR DESCRIPTION
Hi!

Many devs use database_cleaner in conjunction with RSpec, Capybara and Selenium/Capybara-webkit.

I added one line in the readme to link to a post by Avdi Grimm where he shows a proper setup of database_cleaner to work with Capybara and includes a thorough explanation.

It seems to me that easying access to config instructions for such a popular setup will benefit both your gem and new developers.

Cheers!
