### PR TITLE
Add current_fullpath method that returns path with query string.

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -42,7 +42,7 @@ module Capybara
       :title, :assert_title, :assert_no_title, :has_title?, :has_no_title?
     ]
     SESSION_METHODS = [
-      :body, :html, :source, :current_url, :current_host, :current_path,
+      :body, :html, :source, :current_url, :current_host, :current_path, :current_fullpath,
       :execute_script, :evaluate_script, :visit, :go_back, :go_forward,
       :within, :within_fieldset, :within_table, :within_frame, :current_window,
       :windows, :open_new_window, :switch_to_window, :within_window, :window_opened_by,
@@ -156,6 +156,15 @@ module Capybara
     def current_path
       path = URI.parse(current_url).path
       path if path and not path.empty?
+    end
+
+    ##
+    #
+    # @return [String] Path of the current page with query string
+    #
+    def current_fullpath
+      fullpath = URI.parse(current_url).request_uri
+      fullpath if fullpath and not fullpath.empty?
     end
 
     ##


### PR DESCRIPTION
As redundant as `current_path` and `current_host` (URI + `current_url`), but a more common use case than `current_host`, so I think that the convenience is worth it.

80 votes on SO: http://stackoverflow.com/questions/5228371/how-to-get-current-path-with-query-string-using-capybara/25999027#25999027

I will add tests if the feature is accepted.