### PR TITLE
Added methods #previous #next on Node Element to locate closest previous...

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -258,6 +258,17 @@ module Capybara
       rescue NotSupportedByDriverError
         %(#<Capybara::Element tag="#{tag_name}">)
       end
+
+      def previous(html_tag=nil)
+        evaluated_html_tag = html_tag.nil? ? "*" : html_tag
+        self.first(:xpath, "(ancestor::#{evaluated_html_tag}[1]|preceding::#{evaluated_html_tag}[1])[last()]")
+      end
+
+      def next(html_tag=nil)
+        evaluated_html_tag = html_tag.nil? ? "*" : html_tag
+        self.first(:xpath, "following-sibling::#{evaluated_html_tag}[1]")
+      end
+
     end
   end
 end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -326,4 +326,29 @@ Capybara::SpecHelper.spec "node" do
       end
     end
   end
+
+  context "Found a link" do
+    let!(:node){@session.find(:css, 'a[title="a fine link with data method"]')}
+
+    describe "#previous" do
+      it "should find the previous element with the given element tag" do
+        expect(node.previous('a')['title']).to eq('a fine link')
+      end
+
+      it "should find the previous element without a given element tag" do
+        expect(node.previous['title']).to eq('a fine link')
+      end
+    end
+
+    describe "#next" do
+      it "should find the next element with the given element tag" do
+        expect(node.next('a')['title']).to eq('a fine link with capitalized data method')
+      end
+
+      it "should find the next element without a given element tag" do
+        expect(node.next['title']).to eq('a fine link with capitalized data method')
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
#next() finds the next sibling node of the current node.
#previous() finds the first previous element of the current node.
Specs are passing.