### PR TITLE
Make elements returned by `all` and `first` reloadable

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -242,15 +242,12 @@ module Capybara
       end
 
       def reload
-        if @allow_reload
-          begin
-            reloaded = parent.reload.first(@query.name, @query.locator, @query.options)
-            @base = reloaded.base if reloaded
-          rescue => e
-            raise e unless catch_error?(e)
-          end
-        end
+        @index ||= 0 # just for backwards compatibility (in case if `Element` wasn't modified by `Result`)
+        reloaded = parent.reload.all(@query.name, @query.locator, @query.options)[@index]
+        @base = reloaded.base if reloaded
         self
+      rescue => e
+        raise e unless catch_error?(e)
       end
 
       def inspect

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -41,7 +41,7 @@ module Capybara
             raise Capybara::ElementNotFound.new("Unable to find #{query.description}")
           end
           result.first
-        end.tap(&:allow_reload!)
+        end
       end
 
       ##

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -25,6 +25,9 @@ module Capybara
     def initialize(elements, query)
       @elements = elements
       @result = elements.select { |node| query.matches_filters?(node) }
+      @result.each_with_index do |el, index|
+        el.instance_variable_set(:@index, index)
+      end
       @rest = @elements - @result
       @query = query
     end

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -55,6 +55,21 @@ $(function() {
       $('#the-list').html('<li>Foo</li><li>Bar</li>');
     }, 550)
   });
+  $('#four-elements').click(function() {
+    setTimeout(function() {
+      $('#the-list').html('<li>First</li><li>Second</li><li>Third</li><li>Fourth</li>');
+    }, 300)
+  });
+  $('#two-elements').click(function() {
+    setTimeout(function() {
+      $('#the-list').html('<li>Alpha</li><li>Beta</li>');
+    }, 300)
+  });
+  $('#three-elements').click(function() {
+    setTimeout(function() {
+      $('#the-list').html('<li>1</li><li>2</li><li>3</li>');
+    }, 300)
+  });
   $('#change-title').click(function() {
     setTimeout(function() {
       $('title').text('changed title')

--- a/lib/capybara/spec/session/all_spec.rb
+++ b/lib/capybara/spec/session/all_spec.rb
@@ -24,6 +24,32 @@ Capybara::SpecHelper.spec "#all" do
     expect { @session.all('//p', :schmoo => "foo") }.to raise_error(ArgumentError)
   end
 
+  it "should return reloadable elements", requires: [:js] do
+    @session.visit('/with_js')
+    node = @session.all(:css, 'em')[1]
+    @session.click_link('Reload!')
+    sleep(1)
+    expect(node.text).to eq('has been reloaded')
+  end
+
+  it "should return reloadable elements that behave properly when elements are removed or added", requires: [:js] do
+    Capybara.automatic_reload = true
+    @session.visit('/with_js')
+
+    @session.find(:css, '#four-elements').click
+    sleep 0.5
+    node = @session.all(:css, '#the-list > li')[2]
+    expect(node.text).to eq('Third')
+
+    @session.find(:css, '#two-elements').click
+    sleep 0.5
+    expect { node.text }.to raise_error
+
+    @session.find(:css, '#three-elements').click
+    sleep 0.5
+    expect(node.text).to eq('3')
+  end
+
   context "with css selectors" do
     it "should find all elements using the given selector" do
       expect(@session.all(:css, 'h1').first.text).to eq('This is a test')

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -64,6 +64,9 @@
         <li>Item 1</li>
         <li>Item 2</li>
       </ul>
+      <div id="four-elements">Get 4 elements!</div>
+      <div id="two-elements">Get 2 elements!</div>
+      <div id="three-elements">Get 3 elements!</div>
     </p>
 
     <p>


### PR DESCRIPTION
Should fix #1410

All elements are considered reloadable. `#allow_reload!` may be removed from `Element` and `Simple` in next major version as it's not needed with this PR.

One of moments to discuss - currently behavior may be unexpected e.g. in the following case:
```ruby
el = all('li')[-1] # there are 4 'li' elements on the page
find('.remove_last_li').click
expect { el.text } not_to raise_error # I believe that will raise an error as that will search for third element, not for the last one
```

But I don't know at the moment a good solution for it. The problem is that element of enumerable doesn't know the way using which it was got from that enumerable.