### PR TITLE
Use monotonic clock for measuring passed time

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.3.6"
   s.summary = "Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb"
 
+  s.add_runtime_dependency("monotonic_time")
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
   s.add_runtime_dependency("mime-types", [">= 1.16"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])

--- a/lib/capybara/node/base.rb
+++ b/lib/capybara/node/base.rb
@@ -1,3 +1,5 @@
+require 'monotonic_time'
+
 module Capybara
   module Node
 
@@ -63,18 +65,19 @@ module Capybara
       # until a certain amount of time passes. The amount of time defaults to
       # {Capybara.default_wait_time} and can be overridden through the `seconds`
       # argument. This time is compared with the system time to see how much
-      # time has passed. If the return value of `Time.now` is stubbed out,
-      # Capybara will raise `Capybara::FrozenInTime`.
+      # time has passed. If the return value of `MonotonicTime.now` is stubbed
+      # out, Capybara will raise `Capybara::FrozenInTime`.
       #
       # @param  [Integer] seconds         Number of seconds to retry this block
       # @param options [Hash]
       # @option options [Array<Exception>] :errors (driver.invalid_element_errors +
       #   [Capybara::ElementNotFound]) exception types that cause the block to be rerun
       # @return [Object]                  The result of the given block
-      # @raise  [Capybara::FrozenInTime]  If the return value of `Time.now` appears stuck
+      # @raise  [Capybara::FrozenInTime]  If the return value of
+      #   `MonotonicTime.now` appears stuck
       #
       def synchronize(seconds=Capybara.default_wait_time, options = {})
-        start_time = Time.now
+        start_time = MonotonicTime.now
 
         if session.synchronized
           yield
@@ -86,9 +89,9 @@ module Capybara
             session.raise_server_error!
             raise e unless driver.wait?
             raise e unless catch_error?(e, options[:errors])
-            raise e if (Time.now - start_time) >= seconds
+            raise e if (MonotonicTime.now - start_time) >= seconds
             sleep(0.05)
-            raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if Time.now == start_time
+            raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if MonotonicTime.now == start_time
             reload if Capybara.automatic_reload
             retry
           ensure

--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -1,3 +1,5 @@
+require 'monotonic_time'
+
 module Capybara
   module RSpecMatchers
     class Matcher
@@ -130,9 +132,9 @@ module Capybara
 
       def matches?(window)
         @window = window
-        start_time = Time.now
+        start_time = MonotonicTime.now
         while window.exists?
-          return false if (Time.now - start_time) > @wait_time
+          return false if (MonotonicTime.now - start_time) > @wait_time
           sleep 0.05
         end
         true

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -1,3 +1,5 @@
+require 'monotonic_time'
+
 Capybara::SpecHelper.spec '#find' do
   before do
     @session.visit('/with_html')
@@ -60,8 +62,8 @@ Capybara::SpecHelper.spec '#find' do
   context "with frozen time", :requires => [:js] do
     it "raises an error suggesting that Capybara is stuck in time" do
       @session.visit('/with_js')
-      now = Time.now
-      allow(Time).to receive(:now).and_return(now)
+      now = MonotonicTime.now
+      allow(MonotonicTime).to receive(:now).and_return(now)
       expect { @session.find('//isnotthere') }.to raise_error(Capybara::FrozenInTime)
     end
   end


### PR DESCRIPTION
Hello,

Capybara uses real clock to measure time which leads to races when clock is moved 1 hour ahead. This pull requests switches Capybara to use monotonic clock, which doesn't have such problems.

I've used a gem (that depends on hitimes) because supported Ruby includes 1.9.3 and monotonic clock is introduced only in Ruby 2.