### PR TITLE
Add Node#Send keys to standardize usage across drivers

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -50,6 +50,10 @@ module Capybara
         raise NotImplementedError
       end
       
+      def send_keys(*args)
+        raise NotImplementedError
+      end
+      
       def hover
         raise NotImplementedError
       end

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -148,6 +148,79 @@ module Capybara
       def double_click
         synchronize { base.double_click }
       end
+      
+      ##
+      #
+      # Send Keystrokes to the Element
+      #
+      # @param [String, Symbol, Array]
+      #
+      # Examples:
+      #
+      #     element.send_keys "foo"                     #=> value: 'foo'
+      #     element.send_keys "tet", :left, "s"   #=> value: 'test'
+      #     element.send_keys [:control, 'a'], :space   #=> value: ' '
+      #
+      # Symbols supported for keys
+      # :cancel
+      # :help
+      # :backspace
+      # :tab
+      # :clear
+      # :return
+      # :enter
+      # :shift
+      # :control
+      # :alt
+      # :pause
+      # :escape
+      # :space
+      # :page_up
+      # :page_down
+      # :end
+      # :home
+      # :left
+      # :up
+      # :right
+      # :down
+      # :insert
+      # :delete
+      # :semicolon
+      # :equals
+      # :numpad0
+      # :numpad1
+      # :numpad2
+      # :numpad3
+      # :numpad4
+      # :numpad5
+      # :numpad6
+      # :numpad7
+      # :numpad8
+      # :numpad9
+      # :multiply      - numeric keypad *
+      # :add           - numeric keypad +
+      # :separator     - numeric keypad 'separator' key ??
+      # :subtract      - numeric keypad -
+      # :decimal       - numeric keypad .
+      # :divide        - numeric keypad /
+      # :f1
+      # :f2
+      # :f3
+      # :f4
+      # :f5
+      # :f6
+      # :f7
+      # :f8
+      # :f9
+      # :f10
+      # :f11
+      # :f12
+      # :meta         
+      # :command      - alias of :meta
+      #
+      def send_keys(*args)
+        synchronize { base.send_keys(*args) }
+      end
 
       ##
       #

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -80,6 +80,10 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   def double_click
     driver.browser.action.double_click(native).perform
   end
+  
+  def send_keys(*args)
+    native.send_keys(*args)
+  end
 
   def hover
     driver.browser.action.move_to(native).perform

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -100,4 +100,7 @@ $(function() {
       $(this).attr('response', response);
     }
   });
+  $('#with-key-events').keydown(function(e){
+    $('#key-events-output').append('keydown:'+e.which+' ')
+  });
 });

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -251,6 +251,32 @@ Capybara::SpecHelper.spec "node" do
       expect(@session.find(:css, '#has-been-right-clicked')).to be
     end
   end  
+  
+  describe '#send_keys', requires: [:send_keys] do
+    it "should send a string of keys to an element" do
+      @session.visit('/form')
+      @session.find(:css, '#address1_city').send_keys('Oceanside')
+      expect(@session.find(:css, '#address1_city').value).to eq 'Oceanside'
+    end
+    
+    it "should send special characters" do
+      @session.visit('/form')
+      @session.find(:css, '#address1_city').send_keys('Ocean', :space, 'sie', :left, 'd')
+      expect(@session.find(:css, '#address1_city').value).to eq 'Ocean side'
+    end
+    
+    it "should allow for multiple simultaneous keys" do
+      @session.visit('/form')
+      @session.find(:css, '#address1_city').send_keys([:shift, 'o'], 'ceanside')
+      expect(@session.find(:css, '#address1_city').value).to eq 'Oceanside'
+    end
+    
+    it "should generate key events", requires: [:send_keys, :js] do 
+      @session.visit('/with_js')
+      @session.find(:css, '#with-key-events').send_keys([:shift,'t'], [:shift,'w'])
+      expect(@session.find(:css, '#key-events-output')).to have_text('keydown:16 keydown:84 keydown:16 keydown:87')
+    end
+  end
 
   describe '#reload', :requires => [:js] do
     context "without automatic reload" do

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -88,7 +88,11 @@
     <p>
       <a href="#" id="open-prompt">Open prompt</a>
     </p>
-
+    
+    <p>
+      <input type="test" name="with-key-events" id="with-key-events">
+      <p id="key-events-output"></p>
+    </p>
     <script type="text/javascript">
       // a javascript comment
       var aVar = 123;

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -11,6 +11,7 @@ Capybara::SpecHelper.run_specs TestClass.new, "DSL", :capybara_skip => [
   :screenshot,
   :frames,
   :windows,
+  :send_keys,
   :server,
   :hover,
   :about_scheme,

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -10,6 +10,7 @@ Capybara::SpecHelper.run_specs TestSessions::RackTest, "RackTest", :capybara_ski
   :screenshot,
   :frames,
   :windows,
+  :send_keys,
   :server,
   :hover,
   :about_scheme,


### PR DESCRIPTION
Implementation of item discussed in Issue #1459  -  @jferris @jonleighton @mhoran Thoughts on implementing this in your drivers for Capybara 2.5 ?