### PR TITLE
Allow empty attributes by default for Browser#submit and Driver#submit

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -21,7 +21,7 @@ class Capybara::RackTest::Browser
     process_and_follow_redirects(:get, path, attributes)
   end
 
-  def submit(method, path, attributes)
+  def submit(method, path, attributes = {})
     path = request_path if not path or path.empty?
     process_and_follow_redirects(method, path, attributes, {'HTTP_REFERER' => current_url})
   end

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -42,7 +42,7 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     browser.visit(path, attributes)
   end
 
-  def submit(method, path, attributes)
+  def submit(method, path, attributes = {})
     browser.submit(method, path, attributes)
   end
 


### PR DESCRIPTION
Not sure if default value for `attributes` in `#submit` wasn't added intentionally, but adding it seems to improve the API