### PR TITLE
Use native.clear to clear inputs in Selenium::Node

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ Release date: unreleased
 ### Added
 
 * 'formmethod' attribute support in RackTest driver [Emilia Andrzejewska]
+* Clear field using backspaces in Selenium driver by using `:fill_options => { :clear => :backspace }` [Joe Lencioni]
 
 #Version 2.4.4
 Release date: 2014-10-13

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -180,4 +180,24 @@ Capybara::SpecHelper.spec "#fill_in" do
       end.to raise_error(Capybara::ElementNotFound)
     end
   end
+
+  context "with { :clear => :backspace } fill_option", :requires => [:js] do
+    it 'should only trigger onchange once' do
+      @session.visit('/with_js')
+      @session.fill_in('with_change_event', :with => 'some value',
+                       :fill_options => { :clear => :backspace })
+      # click outside the field to trigger the change event
+      @session.find(:css, 'body').click
+      expect(@session.find(:css, '.change_event_triggered', :match => :one)).to have_text 'some value'
+    end
+
+    it 'should trigger change when clearing field' do
+      @session.visit('/with_js')
+      @session.fill_in('with_change_event', :with => '',
+                       :fill_options => { :clear => :backspace })
+      # click outside the field to trigger the change event
+      @session.find(:css, 'body').click
+      expect(@session).to have_selector(:css, '.change_event_triggered', :match => :one)
+    end
+  end
 end


### PR DESCRIPTION
I am developing a React application where we have some controlled inputs. This means that whenever there is an onchange event, we update some application state that ends up re-rendering the input to the DOM. In practice, when testing these fields with Capybara, we've run into issues with the `fill_in` method because of how the inputs are cleared. Running some JS to set the value to empty ended up not working for us because React would immediately clobber the input with the value stored in the application state.

Using `native.clear` to clear an input before filling it in with the desired text more accurately mimics real-world behavior. This allows us to remove a warning comment and helps Capybara work better with codebases that maintain a tight control over the DOM, such as React.js.