### PR TITLE
can find an click links with regex href values

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -21,7 +21,7 @@ module Capybara
       #
       # @param [String] locator         text, id, title or nested image's alt attribute
       # @param options
-      # @option options [String] :href    The value the href attribute must equal
+      # @option options [String, Regexp] :href    The value the href attribute must equal
       #
       def click_link(locator, options={})
         find(:link, locator, options).click

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -220,7 +220,7 @@ module Capybara
       #
       # @param [String] locator           The text or id of a link to check for
       # @param options
-      # @option options [String] :href    The value the href attribute must be
+      # @option options [String, Regexp] :href    The value the href attribute must be
       # @return [Boolean]                 Whether it exists
       #
       def has_link?(locator, options={})

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -149,8 +149,12 @@ end
 
 Capybara.add_selector(:link) do
   xpath { |locator| XPath::HTML.link(locator) }
-  filter(:href) do |node, href|
-    node.first(:xpath, XPath.axis(:self)[XPath.attr(:href).equals(href.to_s)], minimum: 0)
+  filter(:href) do |node, href| 
+    if href.is_a? Regexp
+      node[:href].match href
+    else
+      node.first(:xpath, XPath.axis(:self)[XPath.attr(:href).equals(href.to_s)], minimum: 0)
+    end
   end
   describe { |options| " with href #{options[:href].inspect}" if options[:href] }
 end

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -84,6 +84,28 @@ Capybara::SpecHelper.spec '#click_link' do
     end
   end
 
+  context "with a regex :href option given"  do
+    it "should find a link matching an all-matching regex pattern" do
+      @session.click_link('labore', :href => /.+/)
+      expect(@session).to have_content('Bar')
+    end
+
+    it "should find a link matching an exact regex pattern" do
+      @session.click_link('labore', :href => /\/with_simple_html/)
+      expect(@session).to have_content('Bar') 
+    end
+    
+    it "should find a link matching a partial regex pattern" do
+      @session.click_link('labore', :href => /\/with_simple/)
+      expect(@session).to have_content('Bar')
+    end
+    
+    it "should raise an error if no link's href matched the pattern" do
+      expect { @session.click_link('labore', :href => /invalid_pattern/) }.to raise_error(Capybara::ElementNotFound)
+      expect { @session.click_link('labore', :href => /.+d+/) }.to raise_error(Capybara::ElementNotFound)
+    end
+  end
+
   it "should follow relative links" do
     @session.visit('/')
     @session.click_link('Relative')

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -8,11 +8,13 @@ Capybara::SpecHelper.spec '#has_link?' do
     expect(@session).to have_link('awesome title')
     expect(@session).to have_link('A link', :href => '/with_simple_html')
     expect(@session).to have_link(:'A link', :href => :'/with_simple_html')
+    expect(@session).to have_link('A link', :href => /\/with_simple_html/)
   end
 
   it "should be false if the given link is not on the page" do
     expect(@session).not_to have_link('monkey')
     expect(@session).not_to have_link('A link', :href => '/non-existant-href')
+    expect(@session).not_to have_link('A link', :href => /non-existant/)
   end
 end
 
@@ -30,5 +32,6 @@ Capybara::SpecHelper.spec '#has_no_link?' do
   it "should be true if the given link is not on the page" do
     expect(@session).to have_no_link('monkey')
     expect(@session).to have_no_link('A link', :href => '/non-existant-href')
+    expect(@session).to have_no_link('A link', :href => /\/non-existant-href/)
   end
 end


### PR DESCRIPTION
Adds regex support when searching for links with `href` filters.

Solves #1510.