### PR TITLE
inject_asset_host should not raise if <head> is missing

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -42,10 +42,12 @@ module Capybara
     def inject_asset_host(html)
       if Capybara.asset_host && Nokogiri::HTML(html).css("base").empty?
         match = html.match(/<head[^<]*?>/)
-        html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
-      else
-        html
+        if match
+          return html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
+        end
       end
+
+      html
     end
 
     ##

--- a/lib/capybara/spec/session/save_page_spec.rb
+++ b/lib/capybara/spec/session/save_page_spec.rb
@@ -79,5 +79,13 @@ Capybara::SpecHelper.spec '#save_page' do
       expect(result).to include('<html')
       expect(result).not_to include("http://example.com")
     end
+
+    it "executes successfully even if the page is missing a <head>" do
+      @session.visit("/with_simple_html")
+      path = @session.save_page
+
+      result = File.read(path)
+      expect(result).to include("Bar")
+    end
   end
 end


### PR DESCRIPTION
Previously, if you had Capybara.asset_host defined and tried to
`save_page` on a document without a `<head>` tag (like plain text)
`inject_asset_host` would crash trying to string-replace a `<base>`
tag onto the nonexistant `<head>`.

Since there's probably no need for it to successfully inject a
`<base>` into such documents, now it will return the original content
when there is no `<head>` present.