### PR TITLE
suppress FileNotFound exception in remote test, new config parameter

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -24,7 +24,7 @@ module Capybara
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
     attr_accessor :save_and_open_page_path, :wait_on_first_by_default, :automatic_reload, :raise_server_errors, :server_errors
     attr_writer :default_driver, :current_driver, :javascript_driver, :session_name, :server_host
-    attr_accessor :app
+    attr_accessor :app, :remote
 
     ##
     #

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -142,6 +142,8 @@ module Capybara
       #
       # Find a file field on the page and attach a file given its path. The file field can
       # be found via its name, id or label text.
+      # Exception is raised if file does not exist. This can be suppressed for remote testing scenarios
+      # with the config option config.remote => true
       #
       #     page.attach_file(locator, '/path/to/file.png')
       #
@@ -150,7 +152,7 @@ module Capybara
       #
       def attach_file(locator, path, options={})
         Array(path).each do |p|
-          raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s)
+          raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s) or Capybara.remote
         end
         find(:file_field, locator, options).set(path)
       end

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -88,8 +88,13 @@ Capybara::SpecHelper.spec "#attach_file" do
   end
 
   context "with a path that doesn't exist" do
-    it "should raise an error" do
+    it "should raise an error", :attach_file => true do
       expect { @session.attach_file('Image', '/no_such_file.png') }.to raise_error(Capybara::FileNotFound)
+    end
+
+    it "should not raise an error for remote test", :attach_file => true do
+      Capybara.remote = true
+      expect { @session.attach_file('Image', '/no_such_file.png') }.not_to raise_error
     end
   end
 

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -34,6 +34,7 @@ module Capybara
         Capybara.visible_text_only = false
         Capybara.match = :smart
         Capybara.wait_on_first_by_default = false
+        Capybara.remote = false
       end
 
       def filter(requires, metadata)


### PR DESCRIPTION
capybara may not be running on the same computer as the browser.

I'm testing Internet Explorer on a windows machine running selenium-server. Driving the test from RSpec/capybara running on my Mac. The (Rails) app is also running on the Mac.

However when testing the uploading files using attach_file, capybara raises an exception b/c the file's not present on my Mac. But it's not relevant whether the file's on the Mac, but whether it's present on the windows machine. 

Of course capybara can't check whether the file is present on the windows machine, but at least it should allow the test to continue, and then the expectation should fail. So I added a config parameter (config.remote = true) to inhibit the exception.

I'm kinda surprised nobody's run into this before, so I'm wondering if this is a weird test configuration or if there's some other solution that I'm not seeing. Or maybe people don't test with IE? Anyway, here's a PR with tests for you. To run just the tests relevant to this feature, use the RSpec tag :attach_file => true.