### PR TITLE
Allow RSpec view specs to leverage Capybara matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ describe 'some stuff which requires js', :js => true do
 end
 ```
 
-Finally, Capybara also comes with a built in DSL for creating descriptive acceptance tests:
+Capybara also comes with a built in DSL for creating descriptive acceptance tests:
 
 ```ruby
 feature "Signing in" do
@@ -202,6 +202,20 @@ end
 `feature` is in fact just an alias for `describe ..., :type => :feature`,
 `background` is an alias for `before`, `scenario` for `it`, and
 `given`/`given!` aliases for `let`/`let!`, respectively.
+
+Finally, Capybara matchers are supported in view specs:
+
+```ruby
+RSpec.describe "todos/show.html.erb", type: :view do
+  it "displays the todo title" do
+    assign :todo, Todo.new(title: "Buy milk")
+
+    render
+
+    expect(rendered).to have_css("header h1", text: "Buy milk")
+  end
+end
+```
 
 ## Using Capybara with Test::Unit
 

--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -7,6 +7,7 @@ require 'capybara/rspec/features'
 RSpec.configure do |config|
   config.include Capybara::DSL, :type => :feature
   config.include Capybara::RSpecMatchers, :type => :feature
+  config.include Capybara::RSpecMatchers, :type => :view
 
   # A work-around to support accessing the current example that works in both
   # RSpec 2 and RSpec 3.

--- a/spec/rspec/views_spec.rb
+++ b/spec/rspec/views_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe "capybara/rspec", type: :view do
+  it "allows matchers to be used on strings" do
+    expect(%{<h1>Test header</h1>}).to have_css("h1", text: "Test header")
+  end
+end


### PR DESCRIPTION
Capybara provides a number of helpful matchers for asserting against a
DOM structure with various selectors. RSpec's view specs focus on
asserting against specific markup; this change ensures this is easier
to do.

```ruby
RSpec.describe "todos/show.html.erb", type: :view do
  it "displays the todo title" do
    assign :todo, Todo.new(title: "Buy milk")

    render

    # without Capybara matchers - potentially ambiguous, doesn't
    # test markup, only raw text rendered
    expect(rendered).to contain "Buy milk"

    # with Capybara matchers
    expect(rendered).to have_css("header h1", text: "Buy milk")
  end
end
```