### PR TITLE
Add a :label selector and support for "dynamic" selectors

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -421,7 +421,7 @@ module Capybara
   require 'capybara/session'
   require 'capybara/window'
   require 'capybara/server'
-  require 'capybara/selector'
+  require 'capybara/selectors'
   require 'capybara/result'
   require 'capybara/version'
 

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -74,7 +74,8 @@ module Capybara
         end
       end
 
-      def exact?
+      def exact?(exact = nil)
+        return !!exact unless exact.nil?
         if options.has_key?(:exact)
           @options[:exact]
         else
@@ -91,8 +92,7 @@ module Capybara
       end
 
       def xpath(exact=nil)
-        exact = self.exact? if exact == nil
-        if @expression.respond_to?(:to_xpath) and exact
+        if @expression.respond_to?(:to_xpath) and self.exact?(exact)
           @expression.to_xpath(:exact)
         else
           @expression.to_s
@@ -108,8 +108,10 @@ module Capybara
         node.synchronize do
           children = if selector.format == :css
             node.find_css(self.css)
-          else
+          elsif selector.format == :xpath
             node.find_xpath(self.xpath(exact))
+          elsif selector.format == :dynamic
+            @expression.call(node, self.exact?(exact))
           end.map do |child|
             if node.is_a?(Capybara::Node::Base)
               Capybara::Node::Element.new(node.session, child, node, self)

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+require 'capybara/selector/filter'
+
+module Capybara
+  class Selector
+
+    attr_reader :name, :custom_filters, :format
+
+    class << self
+      def all
+        @selectors ||= {}
+      end
+
+      def add(name, &block)
+        all[name.to_sym] = Capybara::Selector.new(name.to_sym, &block)
+      end
+
+      def update(name, &block)
+        all[name.to_sym].instance_eval(&block)
+      end
+
+      def remove(name)
+        all.delete(name.to_sym)
+      end
+    end
+
+    def initialize(name, &block)
+      @name = name
+      @custom_filters = {}
+      @match = nil
+      @label = nil
+      @failure_message = nil
+      @description = nil
+      @format = nil
+      @expression = nil
+      instance_eval(&block)
+    end
+
+    def xpath(&block)
+      @format, @expression = :xpath, block if block
+      @format == :xpath ? @expression : nil
+    end
+
+    def css(&block)
+      @format, @expression = :css, block if block
+      @format == :css ? @expression : nil
+    end
+
+    def dynamic(&block)
+      @format, @expression = :dynamic, block if block
+      @format == :dynamic ? @expression : nil
+    end
+
+    def match(&block)
+      @match = block if block
+      @match
+    end
+
+    def label(label=nil)
+      @label = label if label
+      @label
+    end
+
+    def description(options={})
+      (@description && @description.call(options)).to_s
+    end
+
+    def call(locator)
+      if format
+        @expression.call(locator)
+      else
+        warn "No selector format"
+      end
+    end
+
+    def match?(locator)
+      @match and @match.call(locator)
+    end
+
+    def filter(name, options={}, &block)
+      @custom_filters[name] = Filter.new(name, block, options)
+    end
+
+    def describe &block
+      @description = block
+    end
+
+    private
+
+    def locate_field(xpath, locator)
+      locate_field = xpath[XPath.attr(:id).equals(locator) |
+                           XPath.attr(:name).equals(locator) |
+                           XPath.attr(:placeholder).equals(locator) |
+                           XPath.attr(:id).equals(XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))]
+      locate_field += XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(xpath)
+      locate_field
+    end
+  end
+end

--- a/lib/capybara/spec/session/selectors_spec.rb
+++ b/lib/capybara/spec/session/selectors_spec.rb
@@ -1,0 +1,35 @@
+Capybara::SpecHelper.spec Capybara::Selector do
+  before do
+    @session.visit('/form')
+  end
+
+  describe ":label selector" do
+    it "finds a label by text" do
+      expect(@session.find(:label, 'Customer Name').text).to eq 'Customer Name'
+    end
+
+    it "finds a label by for attribute" do
+      expect(@session.find(:label, 'form_other_title')['for']).to eq 'form_other_title'
+    end
+
+    it "finds a label from nested input when called with that input" do
+      input = @session.find(:id, 'nested_label')
+      expect(@session.find(:label, input).text).to eq 'Nested Label'
+    end
+
+    it "finds the label for an element when called with that element using 'for' attribute" do
+      select = @session.find(:id, 'form_other_title')
+      expect(@session.find(:label, select)['for']).to eq 'form_other_title'
+    end
+
+    context "with exact option" do
+      it "matches substrings" do
+        expect(@session.find(:label, 'Customer Na', exact: false).text).to eq 'Customer Name'
+      end
+
+      it "doesn't match substrings" do
+        expect { @session.find(:label, 'Customer Na', exact: true) }.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+  end
+end

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -333,6 +333,11 @@ New line after and before textarea tag
 
 <input type="text" name="form[outside_input]" value="outside_input" form="form1"/>
 
+<label>
+  Nested Label
+  <input type="text" name="nested_label" id="nested_label"/>
+</label>
+
 <form id="form1" action="/form" method="post">
   <input type="text" name="form[which_form]" value="form1" id="form_which_form"/>
   <input type="text" name="form[for_form2]" value="for_form2" form="form2"/>


### PR DESCRIPTION
Add a label selector that will take  text, "for" identifer, or the element whose bound label should be found.  It also adds the idea of "dynamic" selectors where the selector receives the locator and the node its being called on and then performs its own finding of nodes instead of just providing a css or xpath expression.  I'm not fully sold on the name "dynamic" yet but haven't come up with anything better