### PR TITLE
Escape url in `current_url`.

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -172,7 +172,7 @@ module Capybara
     # @return [String] Fully qualified URL of the current page
     #
     def current_url
-      driver.current_url
+      URI.escape(driver.current_url)
     end
 
     ##


### PR DESCRIPTION
`URL.parse` in `current_url` will raise an error if url contains any
illegal URI characters.