### PR TITLE
Wait for requests to complete on the server in Session#reset!

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -89,7 +89,7 @@ module Capybara
     end
 
     def wait_for_pending_requests
-      Timeout.timeout(60) { @server_thread.join(0.01) while pending_requests? }
+      Timeout.timeout(60) { sleep(0.01) while pending_requests? }
     rescue Timeout::Error
       raise "Requests did not finish in 60 seconds"
     end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -109,10 +109,19 @@ module Capybara
         assert_no_selector :xpath, "/html/body/*" if driver.browser_initialized?
         @touched = false
       end
+      wait_for_server_requests
       raise_server_error!
     end
     alias_method :cleanup!, :reset!
     alias_method :reset_session!, :reset!
+
+    ##
+    #
+    # Wait for any pending server requests to finish
+    #
+    def wait_for_server_requests
+      @server.wait_for_pending_requests if @server
+    end
 
     ##
     #

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -109,19 +109,11 @@ module Capybara
         assert_no_selector :xpath, "/html/body/*" if driver.browser_initialized?
         @touched = false
       end
-      wait_for_server_requests
+      @server.wait_for_pending_requests if @server
       raise_server_error!
     end
     alias_method :cleanup!, :reset!
     alias_method :reset_session!, :reset!
-
-    ##
-    #
-    # Wait for any pending server requests to finish
-    #
-    def wait_for_server_requests
-      @server.wait_for_pending_requests if @server
-    end
 
     ##
     #

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -124,11 +124,10 @@ RSpec.describe Capybara::Server do
     server = Capybara::Server.new(app).boot
 
     # Start request, but don't wait for it to finish
-    expect {
-      Timeout.timeout(0.1) {
-        Net::HTTP.start(server.host, server.port) { |http| http.get('/') }
-      }
-    }.to raise_error(Timeout::Error)
+    socket = TCPSocket.new(server.host, server.port)
+    socket.write "GET / HTTP/1.0\r\n\r\n"
+    socket.close
+    sleep 0.1
 
     expect(server).to be_pending_requests
     expect(done).to be false

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -129,13 +129,11 @@ RSpec.describe Capybara::Server do
     socket.close
     sleep 0.1
 
-    expect(server).to be_pending_requests
     expect(done).to be false
 
     server.wait_for_pending_requests
 
     # Ensure server was allowed to finish
     expect(done).to be true
-    expect(server).not_to be_pending_requests
   end
 end


### PR DESCRIPTION
It's possible when using a JS driver for a request to continue being processed on the server after calling `Capybara.reset_sessions!`. Though the browser requests are stopped, any requests the server had already started processing will continue.

This causes issues when using capybara with DatabaseCleaner, as the the cleaner might run at the same time as the request, which will likely cause the request to error.

This PR adds a thread-safe counter to Capybara::Server which keeps track of the number of requests currently being processed by `Capybara::Server::Middleware`. It exposes public methods `Server#pending_requests?`, which is truthy when there are requests still being processed, and `Server#wait_for_pending_requests`, which will wait up to 60 seconds for requests to finish.

