### PR TITLE
Ruby warnings

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -328,6 +328,7 @@ module Capybara
 
   self.default_driver = nil
   self.current_driver = nil
+  self.server_host = nil
 
   module Driver; end
   module RackTest; end

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -3,7 +3,7 @@ module Capybara
   module Queries
     class TextQuery < BaseQuery
       def initialize(*args)
-        @type = args.shift if args.first.is_a?(Symbol) || args.first.nil?
+        @type = (args.first.is_a?(Symbol) || args.first.nil?) ? args.shift : nil
         @expected_text, @options = args
         unless @expected_text.is_a?(Regexp)
           @expected_text = Capybara::Helpers.normalize_whitespace(@expected_text)


### PR DESCRIPTION
This PR eliminates some Ruby :warning:s when run with `RUBYOPT="-w"`.

Similar to #599, #897.