### PR TITLE
Implement Capybara::Selenium::Node#path

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -133,6 +133,34 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
     native == other.native
   end
 
+  def path
+    path = parents
+    path.unshift self
+
+    result = []
+    while node = path.shift
+      parent = path.first
+
+      if parent
+        siblings = parent.find_xpath(node.tag_name)
+        if siblings.size == 1
+          result.unshift node.tag_name
+        else
+          index = siblings.index(node)
+          result.unshift "#{node.tag_name}[#{index+1}]"
+        end
+      else
+        result.unshift node.tag_name
+      end
+    end
+
+    '/' + result.join('/')
+  end
+
+  def parents
+    find_xpath('ancestor::*').reverse
+  end
+
 private
 
   # a reference to the select node if this is an option node

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -134,7 +134,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def path
-    path = parents
+    path = find_xpath('ancestor::*').reverse
     path.unshift self
 
     result = []
@@ -155,10 +155,6 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
     end
 
     '/' + result.join('/')
-  end
-
-  def parents
-    find_xpath('ancestor::*').reverse
   end
 
 private

--- a/lib/capybara/spec/views/path.erb
+++ b/lib/capybara/spec/views/path.erb
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <body>
+    <div>
+      <a href="#">First Link</a>
+    </div>
+    Text node
+    <div>
+      <a href="#">Second Link</a>
+      <a href="#">Third Link</a>
+    </div>
+  </body>
+</html>

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -100,6 +100,22 @@ RSpec.describe Capybara::Session do
         expect(@session).to have_selector(:css, '.change_event_triggered', :match => :one)
       end
     end
+
+    describe "#path" do
+      before :each do
+        @session.visit('/with_js')
+      end
+
+      it "returns xpath" do
+        element = @session.find(:css, '#with_focus_event')
+        expect(element.path).to eq('/html/body/p[5]/input')
+      end
+
+      it "returns xpath which points to itself" do
+        element = @session.find(:css, '#with_focus_event')
+        expect(@session.find(:xpath, element.path)).to eq(element)
+      end
+    end
   end
 end
 

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -103,16 +103,16 @@ RSpec.describe Capybara::Session do
 
     describe "#path" do
       before :each do
-        @session.visit('/with_js')
+        @session.visit('/path')
       end
 
       it "returns xpath" do
-        element = @session.find(:css, '#with_focus_event')
-        expect(element.path).to eq('/html/body/p[5]/input')
+        element = @session.find(:link, 'Second Link')
+        expect(element.path).to eq('/html/body/div[2]/a[1]')
       end
 
       it "returns xpath which points to itself" do
-        element = @session.find(:css, '#with_focus_event')
+        element = @session.find(:link, 'Second Link')
         expect(@session.find(:xpath, element.path)).to eq(element)
       end
     end


### PR DESCRIPTION
This PR is to implement`Capybara::Selenium::Node#path`. It now returns a XPath which points to the node, instead of raising `NotSupportedByDriverError`.