### PR TITLE
Update name of wait time config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ looking for that content for a brief time. You can adjust how long this period
 is (the default is 2 seconds):
 
 ```ruby
-Capybara.default_max_wait_time = 5
+Capybara.default_wait_time = 5
 ```
 
 Be aware that because of this behaviour, the following two statements are **not**


### PR DESCRIPTION
`default_max_wait_time` doesn't seem to exist any more. I'm guessing `default_wait_time` is the new name?