### PR TITLE
Adjust has_select filters to allow invisible options in some cases

### DIFF
--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -59,6 +59,11 @@ Capybara::SpecHelper.spec '#has_select?' do
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
+
+    it "should be true even when the selected option invisible, regardless of the select's visibility" do
+      expect(@session).to have_select('Icecream', :visible => false, :selected => 'Chocolate')
+      expect(@session).to have_select('Sorbet', :selected => 'Vanilla')
+    end
   end
 
   context 'with exact options' do
@@ -74,6 +79,11 @@ Capybara::SpecHelper.spec '#has_select?' do
       expect(@session).not_to have_select('Region', :options => ['Norway', 'Sweden'])
       expect(@session).not_to have_select('Region', :options => ['Norway', 'Norway', 'Norway'])
     end
+
+    it" should be true even when the options are invisible, if the select itself is invisible" do
+      expect(@session).to have_select("Icecream", :visible => false, :options => ['Chocolate', 'Vanilla', 'Strawberry'])
+    end
+
   end
 
   context 'with partial options' do
@@ -86,6 +96,10 @@ Capybara::SpecHelper.spec '#has_select?' do
       expect(@session).not_to have_select('Locale', :with_options => ['Uruguayan'])
       expect(@session).not_to have_select('Does not exist', :with_options => ['John'])
       expect(@session).not_to have_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
+    end
+
+    it" should be true even when the options are invisible, if the select itself is invisible" do
+      expect(@session).to have_select("Icecream", :visible => false, :with_options => ['Vanilla', 'Strawberry'])
     end
   end
 end

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -191,6 +191,26 @@ New line after and before textarea tag
     </select>
   </p>
 
+  <!-- invisible select and options -->
+  <p style="display: none">
+    <label for="form_icecream">Icecream</label>
+    <select name="form[icecream]" id="form_icecream">
+      <option selected="selected">Chocolate</option>
+      <option>Vanilla</option>
+      <option>Strawberry</option>
+    </select>
+  </p>
+
+  <!-- visible select with invisible selected option (which some browsers may treat as visible) -->
+  <p>
+    <label for="form_sorbet">Sorbet</label>
+    <select name="form[sorbet]" id="form_sorbet">
+      <option>Chocolate</option>
+      <option selected="selected" style="display: none">Vanilla</option>
+      <option>Strawberry</option>
+    </select>
+  </p>
+
   <p>
     <span>First address<span>
     <label for='address1_street'>Street</label>


### PR DESCRIPTION
This fixes #1579

- selected filter always allows invisible options

- options filter allows invisible options if the select
  itself is invisible

- with_options filter allows invisible options if the select
  itself is invisible


