### PR TITLE
asset_host now overrides href instead of ignoring it

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -40,10 +40,13 @@ module Capybara
     # @return [String]         The modified HTML code
     #
     def inject_asset_host(html)
-      if Capybara.asset_host && Nokogiri::HTML(html).css("base").empty?
-        match = html.match(/<head[^<]*?>/)
-        if match
-          return html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
+      if Capybara.asset_host
+        if Nokogiri::HTML(html).css("base").empty?
+          unless Nokogiri::HTML(html).css("head").empty?
+            html.sub!(/<head[^>]*?>/, "\\0<base href='#{Capybara.asset_host}' />")
+          end
+        else
+          html.sub!(/(<base[^>]*?href\s*=\s*(['"])).*?\2/, "\\1#{Capybara.asset_host}\\2")
         end
       end
 

--- a/lib/capybara/spec/session/save_page_spec.rb
+++ b/lib/capybara/spec/session/save_page_spec.rb
@@ -55,36 +55,31 @@ Capybara::SpecHelper.spec '#save_page' do
 
     it "prepends base tag with value from asset_host to the head" do
       @session.visit("/with_js")
-      path = @session.save_page
 
-      result = File.read(path)
+      result = File.read(@session.save_page)
       expect(result).to include("<head><base href='http://example.com' />")
     end
 
     it "doesn't prepend base tag to pages when asset_host is nil" do
       Capybara.asset_host = nil
       @session.visit("/with_js")
-      path = @session.save_page
 
-      result = File.read(path)
-      expect(result).to include('<html')
+      result = File.read(@session.save_page)
+      expect(result).to include("<html")
       expect(result).not_to include("http://example.com")
     end
 
-    it "doesn't prepend base tag to pages which already have it" do
+    it "overrides existing href attribute" do
       @session.visit("/with_base_tag")
-      path = @session.save_page
 
-      result = File.read(path)
-      expect(result).to include('<html')
-      expect(result).not_to include("http://example.com")
+      result = File.read(@session.save_page)
+      expect(result).to include("href=\"http://example.com\"")
     end
 
     it "executes successfully even if the page is missing a <head>" do
       @session.visit("/with_simple_html")
-      path = @session.save_page
 
-      result = File.read(path)
+      result = File.read(@session.save_page)
       expect(result).to include("Bar")
     end
   end

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -18,6 +18,7 @@ module Capybara
     class << self
       def configure(config)
         config.filter_run_excluding :requires => method(:filter).to_proc
+        config.filter_run_including :focus => true
         config.before { Capybara::SpecHelper.reset! }
         config.after { Capybara::SpecHelper.reset! }
       end


### PR DESCRIPTION
The page I'm testing has `<base>` starting with `/` tag, so local htm dump can't find CSS, etc. because the scheme is `file://`. So I would like to force the correct base in my tests.

I guess the original author https://github.com/jnicklas/capybara/commit/e0591fef5c9b4de9d56f71608043c86aed6a8fa4 made this function ignoring it the base tag already exists because he didn't want to bother with regex. So:
1) I've made it override href attribute if it already exists
2) I've changed the `[^<]` to `[^>]` in regex because I assume it's a bug
3) I've added `:focus` ability to rspec, becuse the `spec_helper.rb` requires all the tests, that makes impossible to run the one specific test
4) note you that different drivers reorder html attributes, that makes me unable to fully test the regex in rspec,, but I'm sure it's fine