### PR TITLE
Temporarily use different options for a driver.

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -90,6 +90,16 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     !@browser.nil?
   end
 
+  def with_options(override_options)
+    original_options = @options
+    @options = @options.merge(override_options)
+
+    yield(self)
+
+    ensure
+      @options = original_options
+  end
+
   def get(*args, &block); browser.get(*args, &block); end
   def post(*args, &block); browser.post(*args, &block); end
   def put(*args, &block); browser.put(*args, &block); end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -168,6 +168,19 @@ RSpec.describe Capybara::RackTest::Driver do
       end
     end
   end
+
+  describe 'temporarily use different options' do
+    it 'temporarily does not follow redirects' do
+      @driver.with_options(follow_redirects: false) do |driver|
+        driver.visit("/redirect_to_get_referer")
+
+        expect(driver.response.status).to eq(302)
+      end
+
+      @driver.visit("/redirect_to_get_referer")
+      expect(@driver.response.status).to eq(200)
+    end
+  end
 end
 
 module CSSHandlerIncludeTester


### PR DESCRIPTION
When testing an action that redirects offsite it is useful to be able to not follow redirects just temporarily when it is enough to assert that a redirection has occured to the correct location.

Currently when using the Capybara::RackTest::Driver an attempt to redirect to an external site results in a request with the same path to the app currently under test. Most of the time this will cause a test to fail as a request is made to a non-existent path.

I know the ethos behind capybara is that it shouldn't do things users can't do with browsers. This is a bending of the rules to improve usability.. so just throwing it out there.. Happy to add some more test cases if you think it might be useful.