### PR TITLE
Don't redefine Object method `method`.

### DIFF
--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -73,8 +73,8 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
 
   def submit(button)
     action = (button && button['formaction']) || native['action']
-    requset_method = (button && button['formmethod']) || method
-    driver.submit(requset_method, action.to_s, params(button))
+    method = (button && button['formmethod']) || request_method
+    driver.submit(method, action.to_s, params(button))
   end
 
   def multipart?
@@ -89,7 +89,7 @@ private
     end
   end
 
-  def method
+  def request_method
     self[:method] =~ /post/i ? :post : :get
   end
 


### PR DESCRIPTION
The `Object` class in Ruby defines an instance method named `method`
that receives a symbol a returns a `Method` object. Byebug uses this
method to grab information about the parameters of each frame in the
backtrace.

The `Capybara::RackTest::Form` class defines a method called `method`,
overriding the method mentioned above. This case could probably be
rescued in `byebug`, but since the method is just a private utility
in the class, I think it is fine to just rename it to something else
inside capybara.

While renaming it, I noticed a typo in a variable name, so I made the
renamings so that the typo is corrected too.

Reference: https://github.com/deivid-rodriguez/byebug/commit/5a634640b4dd40be98e7f8f73abff013a0a6c6e7#diff-4bfdaaf6a5014abdaeae92d370b02373