### PR TITLE
Upgrading mime-types gem to supported version

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.summary = "Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb"
 
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
-  s.add_runtime_dependency("mime-types", [">= 1.16"])
+  s.add_runtime_dependency("mime-types", [">= 3.0"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])
   s.add_runtime_dependency("rack-test", [">= 0.5.4"])
   s.add_runtime_dependency("xpath", ["~> 2.0"])


### PR DESCRIPTION
I am not 100% sure that this is the only change necessary, but the tests pass. 

As per gemnasium recommendation
https://gemnasium.com/jnicklas/capybara

mime-types repo, with version info in readme: https://github.com/mime-types/ruby-mime-types/

![screen shot 2015-12-02 at 11 15 57 am](https://cloud.githubusercontent.com/assets/578159/11541262/26694498-98e6-11e5-80fe-1145086c2f56.png)
![screen shot 2015-12-02 at 11 12 58 am](https://cloud.githubusercontent.com/assets/578159/11541263/266ea9d8-98e6-11e5-9a0f-e7ba32d147f4.png)

