### PR TITLE
Fix circular require

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,6 @@ You can mix the DSL into any context by including <tt>Capybara::DSL</tt>:
 
 
 ```ruby
-require 'capybara'
 require 'capybara/dsl'
 
 Capybara.default_driver = :webkit

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -337,7 +337,6 @@ module Capybara
 
   require 'capybara/helpers'
   require 'capybara/session'
-  require 'capybara/dsl'
   require 'capybara/window'
   require 'capybara/server'
   require 'capybara/selector'

--- a/lib/capybara/cucumber.rb
+++ b/lib/capybara/cucumber.rb
@@ -1,4 +1,4 @@
-require 'capybara'
+require 'capybara/dsl'
 require 'capybara/rspec/matchers'
 
 World(Capybara::DSL)

--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -1,4 +1,3 @@
-require 'capybara'
 require 'capybara/dsl'
 
 Capybara.app = Rack::Builder.new do

--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -1,4 +1,3 @@
-require 'capybara'
 require 'capybara/dsl'
 require 'rspec/core'
 require 'capybara/rspec/matchers'


### PR DESCRIPTION
I was getting a circular require warning while running the `rspec-rails` test suite. This should fix it. Also took the chance to remove some unnecessary requires in other places.