### PR TITLE
Replace deprecated google code Selenium docs with correct GitHub docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ Whatever is returned from the block should conform to the API described by
 Capybara::Driver::Base, it does not however have to inherit from this class.
 Gems can use this API to add their own drivers to Capybara.
 
-The [Selenium wiki](http://code.google.com/p/selenium/wiki/RubyBindings) has
+The [Selenium wiki](https://github.com/SeleniumHQ/selenium/wiki/Ruby-Bindings) has
 additional info about how the underlying driver can be configured.
 
 ## Gotchas:


### PR DESCRIPTION
The Selenium project has moved from code.google.com to github.com, so
this commit modifies the link to the correct wiki page.

There are a few more mentions of code.google.com where two issues are
linked, but the migration to github.com has not included the historical
issues, so those links cannot be updated. The links themselves, though,
do still continue to work.