### PR TITLE
Add `#has_status_code?` in Session Matchers

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -52,7 +52,7 @@ module Capybara
       :windows, :open_new_window, :switch_to_window, :within_window, :window_opened_by,
       :save_page, :save_and_open_page, :save_screenshot,
       :save_and_open_screenshot, :reset_session!, :response_headers,
-      :status_code, :current_scope,
+      :status_code, :has_status_code?, :current_scope,
       :assert_current_path, :assert_no_current_path, :has_current_path?, :has_no_current_path?
     ] + DOCUMENT_METHODS
     MODAL_METHODS = [

--- a/lib/capybara/session/matchers.rb
+++ b/lib/capybara/session/matchers.rb
@@ -1,6 +1,14 @@
 module Capybara
   module SessionMatchers
     ##
+    # Checks if page status equals given `code`.
+    # @return [Boolean]
+    #
+    def has_status_code?(code)
+      driver.status_code == code
+    end
+
+    ##
     # Asserts that the page has the given path.
     # By default this will compare against the path+query portion of the full url
     #

--- a/lib/capybara/spec/session/has_status_code_spec.rb
+++ b/lib/capybara/spec/session/has_status_code_spec.rb
@@ -1,0 +1,9 @@
+Capybara::SpecHelper.spec '#has_status_code?' do
+  before do
+    @session.visit('/form')
+  end
+
+  it 'should return equality of actual and expected session status code' do
+    expect(@session).to have_status_code(200)
+  end
+end


### PR DESCRIPTION
Just a syntactic sugar method that would make RSpec expectations a little better to read.

Usage in RSpec would be:

```Ruby
expect(page).to have_status_code(200)
```

Compared to the current available:

```Ruby
expect(page.status_code).to eq(200)
```

@twalpole 