### PR TITLE
Require addressable gem in CurrentPathQuery

### DIFF
--- a/lib/capybara/queries/current_path_query.rb
+++ b/lib/capybara/queries/current_path_query.rb
@@ -1,3 +1,5 @@
+require 'addressable'
+
 module Capybara
   # @api private
   module Queries


### PR DESCRIPTION
The following commit used `Addressable` to normalize path comparisons: https://github.com/jnicklas/capybara/commit/d6a824c00e8ab9e1d9c76651c729ebe866b2e14b

However, it's now causing a `NameError` exception if the addressable gem is not loaded in the project,
so we're requiring it in this specific location.

*Note:* It isn't failing in the Capybara suite because `launchy` is required in a bunch of tests files, and this gem automatically loaded addressable since it's a dependency.