### PR TITLE
predicates should be boolean

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,10 @@
 # Version 2.7.0
 Release date: unreleased
 
+### Fixed
+* Element#visible?/checked?/disabled?/selected? Now return boolean
+  as expected when using the rack_test driver [Thomas Walpole]
+
 #Version 2.6.2
 Relase date: 2016-01-27
 

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -115,7 +115,7 @@ module Capybara
       # @return [Boolean]     Whether the element is checked
       #
       def checked?
-        native[:checked]
+        native.has_attribute?('checked')
       end
 
       ##
@@ -124,7 +124,7 @@ module Capybara
       #
       # @return [Boolean]     Whether the element is disabled
       def disabled?
-        native[:disabled]
+        native.has_attribute?('disabled')
       end
 
       ##
@@ -134,7 +134,7 @@ module Capybara
       # @return [Boolean]     Whether the element is selected
       #
       def selected?
-        native[:selected]
+        native.has_attribute?('selected')
       end
 
       def synchronize(seconds=nil)

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -159,6 +159,13 @@ Capybara::SpecHelper.spec "node" do
       expect(@session.find('//select[@id="form_disabled_select"]/option')).to be_disabled
       expect(@session.find('//select[@id="form_title"]/option[1]')).not_to be_disabled
     end
+
+    it "should be boolean" do
+      @session.visit('/form')
+      expect(@session.find('//select[@id="form_disabled_select"]/option').disabled?).to be true
+      expect(@session.find('//select[@id="form_disabled_select2"]/option').disabled?).to be true
+      expect(@session.find('//select[@id="form_title"]/option[1]').disabled?).to be false
+    end
   end
 
   describe "#visible?" do
@@ -171,6 +178,12 @@ Capybara::SpecHelper.spec "node" do
       expect(@session.find('//div[@id="hidden_attr"]')).not_to be_visible
       expect(@session.find('//a[@id="hidden_attr_via_ancestor"]')).not_to be_visible
     end
+
+    it "should be boolean" do
+      Capybara.ignore_hidden_elements = false
+      expect(@session.first('//a').visible?).to be true
+      expect(@session.find('//div[@id="hidden"]').visible?).to be false
+    end
   end
 
   describe "#checked?" do
@@ -180,6 +193,13 @@ Capybara::SpecHelper.spec "node" do
       expect(@session.find('//input[@id="gender_male"]')).not_to be_checked
       expect(@session.first('//h1')).not_to be_checked
     end
+
+    it "should be boolean" do
+      @session.visit('/form')
+      expect(@session.find('//input[@id="gender_female"]').checked?).to be true
+      expect(@session.find('//input[@id="gender_male"]').checked?).to be false
+      expect(@session.find('//input[@id="no_attr_value_checked"]').checked?).to be true
+    end
   end
 
   describe "#selected?" do
@@ -188,6 +208,13 @@ Capybara::SpecHelper.spec "node" do
       expect(@session.find('//option[@value="en"]')).to be_selected
       expect(@session.find('//option[@value="sv"]')).not_to be_selected
       expect(@session.first('//h1')).not_to be_selected
+    end
+
+    it "should be boolean" do
+      @session.visit('/form')
+      expect(@session.find('//option[@value="en"]').selected?).to be true
+      expect(@session.find('//option[@value="sv"]').selected?).to be false
+      expect(@session.first('//h1').selected?).to be false
     end
   end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -154,6 +154,10 @@ New line after and before textarea tag
   </p>
 
   <p>
+    <input type="checkbox" id="no_attr_value_checked" value="1" checked/>
+  </p>
+
+  <p>
     <input type="checkbox" value="dog" name="form[pets][]" id="form_pets_dog" checked="checked"/>
     <label for="form_pets_dog">Dog</label>
     <input type="checkbox" value="cat" name="form[pets][]" id="form_pets_cat"/>
@@ -291,6 +295,16 @@ New line after and before textarea tag
       </select>
     </label>
   </p>
+
+  <p>
+    <label for="form_disabled_select2">
+      Disabled Select 2
+      <select name="form[disabled_select2]" id="form_disabled_select2" disabled>
+        <option value="Should not see me" selected="selected">Should not see me</option>
+      </select>
+    </label>
+  </p>
+
 
   <p>
     <label for="form_disabled_file">


### PR DESCRIPTION
#visible?, #disabled?, #checked?, #selected? should return a boolean as documented - this was not the case with the rack_test driver which was instead returning the attribute value for some of the predicates.