### PR TITLE
Readme rspec typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ require 'capybara/rspec'
 
 If you are using Rails, put your Capybara specs in `spec/features` (only works
 if [you have it configured in
-rspec](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled))
+RSpec](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled))
 and if you have your Capybara specs in a different directory, then tag the
 example groups with `:type => :feature`.
 
@@ -735,7 +735,7 @@ The former would immediately fail because the content has not yet been removed.
 Only the latter would wait for the asynchronous process to remove the content
 from the page.
 
-Capybara's Rspec matchers, however, are smart enough to handle either form.
+Capybara's RSpec matchers, however, are smart enough to handle either form.
 The two following statements are functionally equivalent:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ require 'capybara/rspec'
 
 If you are using Rails, put your Capybara specs in `spec/features` (only works
 if [you have it configured in
-rpsec](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled))
+rspec](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled))
 and if you have your Capybara specs in a different directory, then tag the
 example groups with `:type => :feature`.
 


### PR DESCRIPTION
In the README, "rspec" was misspelled as "rpsec" in one place. While I was in there, I noticed a few spots where the official "RSpec" capitalization wasn't used, so I went ahead and made those consistent as well.

Thanks for this great library! Hopefully someday I'll have a more substantive PR to contribute =]