### PR TITLE
Add documention for Capybara::Node::Actions#attach_file options hash

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -150,6 +150,11 @@ module Capybara
       # @param [String] locator       Which field to attach the file to
       # @param [String] path          The path of the file that will be attached, or an array of paths
       #
+      # @option options [Symbol] match     The matching strategy to use (:one, :first, :prefer_exact, :smart)
+      # @option options [Boolean] exact    Match the exact locator name or accept a partial match
+      # @option options [Fixnum] wait      If using a Javascript driver, number of seconds during which the element will be searched for.
+      # @option options [Boolean] multiple Match field which allows multiple file selection
+      #
       def attach_file(locator, path, options={})
         Array(path).each do |p|
           raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s)

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -150,10 +150,10 @@ module Capybara
       # @param [String] locator       Which field to attach the file to
       # @param [String] path          The path of the file that will be attached, or an array of paths
       #
-      # @option options [Symbol] match (:smart)     The matching strategy to use (:one, :first, :prefer_exact, :smart).
-      # @option options [Boolean] exact (true)    Match the exact label name/contents or accept a partial match.
+      # @option options [Symbol] match (Capybara.match)     The matching strategy to use (:one, :first, :prefer_exact, :smart).
+      # @option options [Boolean] exact (Capybara.exact)    Match the exact label name/contents or accept a partial match.
       # @option options [Fixnum] wait (Capybara.default_max_wait_time)      If using a Javascript driver, maximum number of seconds during which the element will be searched for.
-      # @option options [Boolean] multiple (true) Match field which allows multiple file selection
+      # @option options [Boolean] multiple Match field which allows multiple file selection
       #
       def attach_file(locator, path, options={})
         Array(path).each do |p|

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -150,10 +150,10 @@ module Capybara
       # @param [String] locator       Which field to attach the file to
       # @param [String] path          The path of the file that will be attached, or an array of paths
       #
-      # @option options [Symbol] match     The matching strategy to use (:one, :first, :prefer_exact, :smart)
-      # @option options [Boolean] exact    Match the exact locator name or accept a partial match
-      # @option options [Fixnum] wait      If using a Javascript driver, number of seconds during which the element will be searched for.
-      # @option options [Boolean] multiple Match field which allows multiple file selection
+      # @option options [Symbol] match (:smart)     The matching strategy to use (:one, :first, :prefer_exact, :smart).
+      # @option options [Boolean] exact (true)    Match the exact label name/contents or accept a partial match.
+      # @option options [Fixnum] wait (Capybara.default_max_wait_time)      If using a Javascript driver, maximum number of seconds during which the element will be searched for.
+      # @option options [Boolean] multiple (true) Match field which allows multiple file selection
       #
       def attach_file(locator, path, options={})
         Array(path).each do |p|


### PR DESCRIPTION
This PR adds some missing documentation for the `attach_file` method, which takes an options hash but didn't previously document what parameters it accepted. Please let me know if the descriptions make sense.

This is a fix for #1659