### PR TITLE
Default to localhost, not 127.0.0.1, if the system prefers IPv6

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -295,7 +295,7 @@ module Capybara
     # @return [String]    The IP address bound by default server
     #
     def server_host
-      @server_host || '127.0.0.1'
+      @server_host || 'localhost'
     end
 
     ##

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -65,7 +65,7 @@ module Capybara
       @server_thread = nil # suppress warnings
       @host, @port = host, port
       @port ||= Capybara::Server.ports[Capybara.reuse_server ? @app.object_id : @middleware.object_id]
-      @port ||= find_available_port
+      @port ||= find_available_port(host)
     end
 
     def reset_error!
@@ -112,8 +112,8 @@ module Capybara
 
   private
 
-    def find_available_port
-      server = TCPServer.new('127.0.0.1', 0)
+    def find_available_port(host)
+      server = TCPServer.new(host, 0)
       server.addr[1]
     ensure
       server.close if server


### PR DESCRIPTION
In eventmachine/eventmachine#703, we found that Capybara.server_host defaults to `127.0.0.1`, while Thin defaults to `localhost`. With the new EventMachine 1.2.0 gem, we're using the system's `getaddrinfo` to return both IPv4 and IPv6 addresses in whichever order the local operating system prefers. This allows Thin to bind to `::1` by default, but Capybara's default of `127.0.0.1` fails to connect.

By allowing Capybara to also follow the local operating system preference, both client and server will bind and talk on the same local IP address.