### PR TITLE
move xpath gem html definitions into capybara

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ Release date: unreleased
 * Element#visible?/checked?/disabled?/selected? Now return boolean
   as expected when using the rack_test driver [Thomas Walpole]
 * The rack_test driver now considers \<input type="hidden"> elements as non-visible [Thomas Walpole]
+* A nil locator passed to the built-in html type selectors now behaves consistently, and finds all elements of the correct type [Thomas Walpole]
 
 ### Added
 * :multiple filter added to relevant selectors [Thomas Walpole]

--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("cucumber", [">= 0.10.5"])
   s.add_development_dependency("rake", ["< 11.0"])
   s.add_development_dependency("pry")
+  s.add_development_dependency("byebug")
 
   if RUBY_ENGINE == 'rbx' then
     s.add_development_dependency("racc")

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Capybara do
               <p class="b">Some Content</p>
               <p class="b"></p>
             </div>
+            <input type="checkbox"/>
+            <input type="radio"/>
+            <input type="text"/>
+            <input type="file"/>
+            <a href="#">link</a>
+            <fieldset></fieldset>
+            <select>
+              <option value="a">A</option>
+            </select>
+            <table>
+              <tr><td></td></tr>
+            </table
           </body>
         </html>
       STRING
@@ -48,6 +60,29 @@ RSpec.describe Capybara do
         expect(string).to have_selector(:custom_selector, 'b', count: 1)
         expect(string).to have_selector(:custom_selector, 'b', not_empty: false, count: 1)
         expect(string).to have_selector(:custom_selector, 'b', not_empty: :all, count: 2)
+      end
+    end
+
+    describe "builtin selectors with nil locators" do
+      it "devolves to just finding element types" do
+        selectors = {
+          field: ".//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]",
+          fieldset: ".//fieldset",
+          link: ".//a[./@href]",
+          link_or_button: ".//a[./@href] | .//input[./@type = 'submit' or ./@type = 'reset' or ./@type = 'image' or ./@type = 'button'] | .//button" ,
+          fillable_field: ".//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]",
+          radio_button: ".//input[./@type = 'radio']",
+          checkbox: ".//input[./@type = 'checkbox']",
+          select: ".//select",
+          option: ".//option",
+          file_field: ".//input[./@type = 'file']",
+          table: ".//table"
+        }
+        selectors.each do |selector, xpath|
+          results = string.all(selector,nil).to_a.map &:native
+          expect(results.size).to be > 0
+          expect(results).to eq string.all(:xpath, xpath).to_a.map(&:native)
+        end
       end
     end
   end


### PR DESCRIPTION
Move the html element selector definitions from the xpath gem into the capybara selectors and modify them so nil locators devolve into just finding element types