### PR TITLE
Selenium driver reset synchronous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 addons:
+  firefox: latest
   apt:
     sources:
       - google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,15 @@ sudo: false
 rvm:
   - 2.0.0
   - 2.2
-  - 2.3.0
   - jruby-9.0.3.0
   - rbx-2
 gemfile:
   - Gemfile
 matrix:
   include:
+    - gemfile: Gemfile
+      rvm: 2.3.0
+      env: WINDOW_TEST=true
     - gemfile: gemfiles/Gemfile.ruby-19
       rvm: 1.9.3
     - gemfile: gemfiles/Gemfile.ruby-19

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -134,4 +134,10 @@ class Capybara::Driver::Base
   def needs_server?
     false
   end
+
+  # @deprecated This method is being removed
+  def browser_initialized?
+    warn "DEPRECATED: #browser_initialized? is deprecated and will be removed in the next version of Capybara"
+    true
+  end
 end

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -91,8 +91,8 @@ class Capybara::Driver::Base
   def no_such_window_error
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#no_such_window_error'
   end
-  
-  
+
+
   ##
   #
   # Execute the block, and then accept the modal opened.
@@ -133,9 +133,5 @@ class Capybara::Driver::Base
 
   def needs_server?
     false
-  end
-
-  def browser_initialized?
-    true
   end
 end

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -87,6 +87,11 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     @browser = nil
   end
 
+  # @deprecated This method is being removed
+  def browser_initialized?
+    super && !@browser.nil?
+  end
+
   def get(*args, &block); browser.get(*args, &block); end
   def post(*args, &block); browser.post(*args, &block); end
   def put(*args, &block); browser.put(*args, &block); end

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -66,11 +66,11 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
   def find_xpath(selector)
     browser.find(:xpath, selector)
   end
-  
+
   def find_css(selector)
     browser.find(:css,selector)
   end
-  
+
   def html
     browser.html
   end
@@ -78,17 +78,13 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
   def dom
     browser.dom
   end
-  
+
   def title
     browser.title
   end
 
   def reset!
     @browser = nil
-  end
-
-  def browser_initialized?
-    !@browser.nil?
   end
 
   def get(*args, &block); browser.get(*args, &block); end

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -92,20 +92,35 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   def reset!
     # Use instance variable directly so we avoid starting the browser just to reset the session
     if @browser
+      navigated = false
+      start_time = Capybara::Helpers.monotonic_time
       begin
-        begin @browser.manage.delete_all_cookies
-        rescue Selenium::WebDriver::Error::UnhandledError
-          # delete_all_cookies fails when we've previously gone
-          # to about:blank, so we rescue this error and do nothing
-          # instead.
+        if !navigated
+          # Only trigger a navigation if we haven't done it already, otherwise it
+          # can trigger an endless series of unload modals
+          begin
+            @browser.manage.delete_all_cookies
+          rescue Selenium::WebDriver::Error::UnhandledError
+            # delete_all_cookies fails when we've previously gone
+            # to about:blank, so we rescue this error and do nothing
+            # instead.
+          end
+          @browser.navigate.to("about:blank")
         end
-        @browser.navigate.to("about:blank")
+        navigated = true
+
+        #Ensure the page is empty and trigger an UnhandledAlertError for any modals that appear during unload
+        until find_xpath("/html/body/*").empty? do
+          raise Capybara::ExpectationNotMet.new('Timed out waiting for Selenium session reset') if (Capybara::Helpers.monotonic_time - start_time) >= 10
+          sleep 0.05
+        end
       rescue Selenium::WebDriver::Error::UnhandledAlertError
         # This error is thrown if an unhandled alert is on the page
         # Firefox appears to automatically dismiss this alert, chrome does not
         # We'll try to accept it
         begin
           @browser.switch_to.alert.accept
+          sleep 0.25 # allow time for the modal to be handled
         rescue Selenium::WebDriver::Error::NoAlertPresentError
           # The alert is now gone - nothing to do
         end

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -263,6 +263,11 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     Selenium::WebDriver::Error::NoSuchWindowError
   end
 
+  # @deprecated This method is being removed
+  def browser_initialized?
+    super && !@browser.nil?
+  end
+
   private
 
   def within_given_window(handle)

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -248,10 +248,6 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     Selenium::WebDriver::Error::NoSuchWindowError
   end
 
-  def browser_initialized?
-    !@browser.nil?
-  end
-
   private
 
   def within_given_window(handle)

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -107,7 +107,6 @@ module Capybara
     def reset!
       if @touched
         driver.reset!
-        assert_no_selector :xpath, "/html/body/*" if driver.browser_initialized?
         @touched = false
       end
       @server.wait_for_pending_requests if @server

--- a/lib/capybara/spec/session/reset_session_spec.rb
+++ b/lib/capybara/spec/session/reset_session_spec.rb
@@ -33,8 +33,16 @@ Capybara::SpecHelper.spec '#reset_session!' do
   end
 
   it "is synchronous" do
-    @session.visit("/with_html")
+    @session.visit("/with_slow_unload")
+    expect(@session).to have_selector(:css, 'div')
     @session.reset_session!
+    expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
+  end
+
+  it "handles modals during unload" do
+    @session.visit('/with_unload_alert')
+    expect(@session).to have_selector(:css, 'div')
+    expect { @session.reset_session! }.not_to raise_error
     expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
   end
 

--- a/lib/capybara/spec/views/with_slow_unload.erb
+++ b/lib/capybara/spec/views/with_slow_unload.erb
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <script>
+    function delay_unload() {
+      var start = new Date();
+      var i = 0;
+      while ((new Date()) - start < 1000){ i = i + 1; };
+      return null;
+    }
+    window.onbeforeunload = delay_unload;
+    window.onunload = delay_unload;
+  </script>
+</head>
+<body>
+  <div>This delays unload by 2 seconds</div>
+</body>
+</html>

--- a/lib/capybara/spec/views/with_unload_alert.erb
+++ b/lib/capybara/spec/views/with_unload_alert.erb
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <script>
+      window.onbeforeunload = function(e) {
+        return 'Unload?';
+      };
+  </script>
+</head>
+<body>
+  <div>This triggers an alert on unload</div>
+</body>
+</html>

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -12,11 +12,14 @@ module TestSessions
   Selenium = Capybara::Session.new(:selenium_focus, TestApp)
 end
 
-Capybara::SpecHelper.run_specs TestSessions::Selenium, "selenium", :capybara_skip => [
+skipped_tests = [
   :response_headers,
   :status_code,
   :trigger
 ]
+skipped_tests << :windows if ENV['TRAVIS'] && !ENV['WINDOW_TEST']
+
+Capybara::SpecHelper.run_specs TestSessions::Selenium, "selenium", :capybara_skip => skipped_tests
 
 RSpec.describe Capybara::Session do
   context 'with selenium driver' do


### PR DESCRIPTION
Make sure `#reset` for the selenium driver is synchronous and handles modals that may appear.