### PR TITLE
Fix "bald contenteditable" bug

### DIFF
--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -126,12 +126,19 @@ Capybara::SpecHelper.spec "node" do
       expect(@session.find(:css,'#blank_content_editable').text).to eq('WYSIWYG')
     end
 
+    it 'should allow me to change the contents of a contenteditable without =true', :requires => [:js] do
+      @session.visit('/with_js')
+      @session.find(:css,'#sleek_content_editable').set('WYSIWYG')
+      expect(@session.find(:css,'#existing_content_editable_child').text).to eq('WYSIWYG')
+    end
+
     it 'should allow me to change the contents of a contenteditable elements child', :requires => [:js] do
       pending "Selenium doesn't like editing nested contents"
       @session.visit('/with_js')
       @session.find(:css,'#existing_content_editable_child').set('WYSIWYG')
       expect(@session.find(:css,'#existing_content_editable_child').text).to eq('WYSIWYG')
     end
+
   end
 
   describe "#tag_name" do

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -40,6 +40,7 @@
     <p>
       <div contenteditable='true' id='existing_content_editable'>Editable content</div>
       <div contenteditable='true' id='blank_content_editable' style='height: 1em;'></div>
+      <div contenteditable id='sleek_content_editable'>Editable content</div>
       <div contenteditable='true' style='height: 1em;'>
         <div id='existing_content_editable_child' style='height: 1em;'>Content</div>
       </div>


### PR DESCRIPTION
A "bald contenteditable" is one added to an element like this:

    <div contenteditable>

Rather than this:

    <div contenteditable="true">

The latter is currently supported by Capybara, but the former is not.