### PR TITLE
Click associated label when checkbox/radio button is hidden

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 # Version 2.8.0
 Release date: Unreleased
 
+### Fixed
+
+### Added
+* 'check', 'uncheck', and 'choose' will now click the associated label if the checkbox/radio button is not visible
+
 # Version 2.7.0
 Release date: 2016-04-07
 

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -79,6 +79,9 @@ module Capybara
         find(:fillable_field, locator, options).set(with, fill_options)
       end
 
+      # @!macro click_label
+      #   @option options [Boolean] :click_label (true) Attempt to click the label to toggle state if element is non-visible.
+
       ##
       #
       # Find a radio button and mark it as checked. The radio button can be found
@@ -86,18 +89,20 @@ module Capybara
       #
       #     page.choose('Male')
       #
-      # @macro waiting_behavior
-      #
       # @overload choose([locator], options)
       #   @param [String] locator           Which radio button to choose
       #
       #   @option options [String] :option  Value of the radio_button to choose
-      #
+      #   @macro waiting_behavior
+      #   @macro click_label
       def choose(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
+        allow_click_label = options.delete(:click_label) { true }
+
         begin
           find(:radio_button, locator, options).set(true)
         rescue Capybara::ElementNotFound => e
+          raise unless allow_click_label
           begin
             radio = find(:radio_button, locator, options.merge({wait: 0, visible: :hidden}))
             label = find(:label, for: radio, wait: 0, visible: true)
@@ -115,18 +120,22 @@ module Capybara
       #
       #     page.check('German')
       #
-      # @macro waiting_behavior
       #
       # @overload check([locator], options)
       #   @param [String] locator           Which check box to check
       #
       #   @option options [String] :option  Value of the checkbox to select
+      #   @macro click_label
+      #   @macro waiting_behavior
       #
       def check(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
+        allow_click_label = options.delete(:click_label) { true }
+
         begin
           find(:checkbox, locator, options).set(true)
         rescue Capybara::ElementNotFound => e
+          raise unless allow_click_label
           begin
             cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :hidden}))
             label = find(:label, for: cbox, wait: 0, visible: true)
@@ -144,18 +153,22 @@ module Capybara
       #
       #     page.uncheck('German')
       #
-      # @macro waiting_behavior
       #
       # @overload uncheck([locator], options)
       #   @param [String] locator           Which check box to uncheck
       #
       #   @option options [String] :option  Value of the checkbox to deselect
+      #   @macro click_label
+      #   @macro waiting_behavior
       #
       def uncheck(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
+        allow_click_label = options.delete(:click_label) { true }
+
         begin
           find(:checkbox, locator, options).set(false)
         rescue Capybara::ElementNotFound => e
+          raise unless allow_click_label
           begin
             cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :hidden}))
             label = find(:label, for: cbox, wait: 0, visible: true)

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -114,7 +114,17 @@ module Capybara
       #
       def check(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
-        find(:checkbox, locator, options).set(true)
+        begin
+          find(:checkbox, locator, options).set(true)
+        rescue Capybara::ElementNotFound => e
+          begin
+            cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :all}))
+            label = find(:label, for: cbox, wait: 0)
+            label.click if !cbox.checked?
+          rescue
+            raise e
+          end
+        end
       end
 
       ##
@@ -133,7 +143,17 @@ module Capybara
       #
       def uncheck(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
-        find(:checkbox, locator, options).set(false)
+        begin
+          find(:checkbox, locator, options).set(false)
+        rescue Capybara::ElementNotFound => e
+          begin
+            cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :all}))
+            label = find(:label, for: cbox, wait: 0)
+            label.click if cbox.checked?
+          rescue
+            raise e
+          end
+        end
       end
 
       ##

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -95,7 +95,17 @@ module Capybara
       #
       def choose(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
-        find(:radio_button, locator, options).set(true)
+        begin
+          find(:radio_button, locator, options).set(true)
+        rescue Capybara::ElementNotFound => e
+          begin
+            radio = find(:radio_button, locator, options.merge({wait: 0, visible: :hidden}))
+            label = find(:label, for: radio, wait: 0, visible: true)
+            label.click unless radio.checked?
+          rescue
+            raise e
+          end
+        end
       end
 
       ##
@@ -118,9 +128,9 @@ module Capybara
           find(:checkbox, locator, options).set(true)
         rescue Capybara::ElementNotFound => e
           begin
-            cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :all}))
-            label = find(:label, for: cbox, wait: 0)
-            label.click if !cbox.checked?
+            cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :hidden}))
+            label = find(:label, for: cbox, wait: 0, visible: true)
+            label.click unless cbox.checked?
           rescue
             raise e
           end
@@ -147,8 +157,8 @@ module Capybara
           find(:checkbox, locator, options).set(false)
         rescue Capybara::ElementNotFound => e
           begin
-            cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :all}))
-            label = find(:label, for: cbox, wait: 0)
+            cbox = find(:checkbox, locator, options.merge({wait: 0, visible: :hidden}))
+            label = find(:label, for: cbox, wait: 0, visible: true)
             label.click if cbox.checked?
           rescue
             raise e

--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -60,6 +60,16 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
         ((tag_name == 'button') and type.nil? or type == "submit")
       associated_form = form
       Capybara::RackTest::Form.new(driver, associated_form).submit(self) if associated_form
+    elsif (tag_name == 'label')
+      labelled_control = if native[:for]
+        find_xpath("//input[@id='#{native[:for]}']").first
+      else
+        find_xpath(".//input").first
+      end
+
+      if labelled_control && (labelled_control.checkbox? || labelled_control.radio?)
+        labelled_control.set(!labelled_control.checked?)
+      end
     end
   end
 
@@ -182,6 +192,8 @@ private
   def attribute_is_not_blank?(attribute)
     self[attribute] && !self[attribute].empty?
   end
+
+protected
 
   def checkbox?
     input_field? && type == 'checkbox'

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -368,6 +368,11 @@ Capybara.add_selector(:label) do
       node[:for] == field_or_value.to_s
     end
   end
+
+  describe do |options|
+    desc = String.new
+    desc << " for #{options[:for]}" if options[:for]
+  end
 end
 
 Capybara.add_selector(:table) do

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -112,7 +112,7 @@ Capybara::SpecHelper.spec "#check" do
     end
   end
 
-  context "when checkbox hidden", hidden: true do
+  context "when checkbox hidden" do
     it "should check via clicking the label with :for attribute if possible" do
       expect(@session.find(:checkbox, 'form_cars_tesla', unchecked: true, visible: :hidden)).to be
       @session.check('form_cars_tesla')
@@ -136,6 +136,10 @@ Capybara::SpecHelper.spec "#check" do
 
     it "should raise original error when no label available" do
       expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel"')
+    end
+
+    it "should raise error if not allowed to click label" do
+      expect{@session.check('form_cars_mclaren', click_label: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren"')
     end
   end
 end

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -111,4 +111,31 @@ Capybara::SpecHelper.spec "#check" do
       end.to raise_error(Capybara::ElementNotFound)
     end
   end
+
+  context "when checkbox hidden", hidden: true do
+    it "should check via clicking the label with :for attribute if possible" do
+      expect(@session.find(:checkbox, 'form_cars_tesla', unchecked: true, visible: :hidden)).to be
+      @session.check('form_cars_tesla')
+      @session.click_button('awesome')
+      expect(extract_results(@session)['cars']).to include('tesla')
+    end
+
+    it "should check via clicking the wrapping label if possible" do
+      expect(@session.find(:checkbox, 'form_cars_mclaren', unchecked: true, visible: :hidden)).to be
+      @session.check('form_cars_mclaren')
+      @session.click_button('awesome')
+      expect(extract_results(@session)['cars']).to include('mclaren')
+    end
+
+    it "should not click the label if unneeded" do
+      expect(@session.find(:checkbox, 'form_cars_jaguar', checked: true, visible: :hidden)).to be
+      @session.check('form_cars_jaguar')
+      @session.click_button('awesome')
+      expect(extract_results(@session)['cars']).to include('jaguar')
+    end
+
+    it "should raise original error when no label available" do
+      expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel"')
+    end
+  end
 end

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -66,4 +66,12 @@ Capybara::SpecHelper.spec "#choose" do
       end.to raise_error(Capybara::ElementNotFound)
     end
   end
+
+  context "with hidden radio buttons", hidden: true do
+    it "should select by clicking the link if available" do
+      @session.choose("party_democrat")
+      @session.click_button('awesome')
+      expect(extract_results(@session)['party']).to eq('democrat')
+    end
+  end
 end

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -67,11 +67,15 @@ Capybara::SpecHelper.spec "#choose" do
     end
   end
 
-  context "with hidden radio buttons", hidden: true do
+  context "with hidden radio buttons" do
     it "should select by clicking the link if available" do
       @session.choose("party_democrat")
       @session.click_button('awesome')
       expect(extract_results(@session)['party']).to eq('democrat')
+    end
+
+    it "should raise error if not allowed to click label" do
+      expect{@session.choose("party_democrat", click_label: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find radio button "party_democrat"')
     end
   end
 end

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -39,7 +39,7 @@ Capybara::SpecHelper.spec "#uncheck" do
     end
   end
 
-  context "when checkbox hidden", hidden: true do
+  context "when checkbox hidden" do
     it "should uncheck via clicking the label with :for attribute if possible" do
       expect(@session.find(:checkbox, 'form_cars_jaguar', checked: true, visible: :hidden)).to be
       @session.uncheck('form_cars_jaguar')
@@ -63,6 +63,10 @@ Capybara::SpecHelper.spec "#uncheck" do
 
     it "should raise original error when no label available" do
       expect { @session.uncheck('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel"')
+    end
+
+    it "should raise error if not allowed to click label" do
+      expect{@session.uncheck('form_cars_jaguar', click_label: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_jaguar"')
     end
   end
 end

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -38,4 +38,31 @@ Capybara::SpecHelper.spec "#uncheck" do
       end.to raise_error(Capybara::ElementNotFound)
     end
   end
+
+  context "when checkbox hidden", hidden: true do
+    it "should uncheck via clicking the label with :for attribute if possible" do
+      expect(@session.find(:checkbox, 'form_cars_jaguar', checked: true, visible: :hidden)).to be
+      @session.uncheck('form_cars_jaguar')
+      @session.click_button('awesome')
+      expect(extract_results(@session)['cars']).not_to include('jaguar')
+    end
+
+    it "should uncheck via clicking the wrapping label if possible" do
+      expect(@session.find(:checkbox, 'form_cars_koenigsegg', checked: true, visible: :hidden)).to be
+      @session.uncheck('form_cars_koenigsegg')
+      @session.click_button('awesome')
+      expect(extract_results(@session)['cars']).not_to include('koenigsegg')
+    end
+
+    it "should not click the label if unneeded" do
+      expect(@session.find(:checkbox, 'form_cars_tesla', unchecked: true, visible: :hidden)).to be
+      @session.uncheck('form_cars_tesla')
+      @session.click_button('awesome')
+      expect(extract_results(@session)['cars']).not_to include('tesla')
+    end
+
+    it "should raise original error when no label available" do
+      expect { @session.uncheck('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel"')
+    end
+  end
 end

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -168,6 +168,24 @@ New line after and before textarea tag
   </p>
 
   <p>
+    <input type="checkbox" value="jaguar" name="form[cars][]" id="form_cars_jaguar" checked="checked" style="display: none"/>
+    <label for="form_cars_jaguar">Jaguar</label>
+    <input type="checkbox" value="tesla" name="form[cars][]" id="form_cars_tesla" style="display: none"/>
+    <label for="form_cars_tesla">Tesla</label>
+    <input type="checkbox" value="ferrari" name="form[cars][]" id="form_cars_ferrari" checked="checked" style="display: none"/>
+    <label for="form_cars_ferrari">Ferrari</label>
+    <input type="checkbox" value="ariel" name="form[cars][]" id="form_cars_ariel" style="display: none"/>
+    <label>
+      McLaren
+      <input type="checkbox" value="mclaren" name="form[cars][]" id="form_cars_mclaren" style="display: none"/>
+    </label>
+    <label>
+      Koenigsegg
+      <input type="checkbox" value="koenigsegg" name="form[cars][]" id="form_cars_koenigsegg" checked="checked" style="display: none"/>
+    </label>
+  </p>
+
+  <p>
     <input type="checkbox" name="form[valueless_checkbox]" id="valueless_checkbox" checked="checked"/>
     <label for="valueless_checkbox">Valueless Checkbox</label>
     <input type="radio" name="form[valueless_radio]" id="valueless_radio" checked="checked"/>

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -155,6 +155,15 @@ New line after and before textarea tag
   </p>
 
   <p>
+    <input type="radio" name="form[party]" value="democrat" id="party_democrat" style="display:none"/>
+    <label for="party_democrat">Democrat</label>
+    <input type="radio" name="form[party]" value="republican" id="party_republican" style="display:none"/>
+    <label for="party_republican">Republican</label>
+    <input type="radio" name="form[party]" value="independent" id="party_independent" checked="checked" style="display:none"/>
+    <label for="party_independent">Independent</label>
+  </p>
+
+  <p>
     <input type="checkbox" id="no_attr_value_checked" value="1" checked/>
   </p>
 

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe Capybara::Session do
         end
       end
     end
+
+    describe "#click" do
+      context "on a label" do
+        it "should toggle the associated checkbox" do
+          @session.visit("/form")
+          expect(@session).to have_unchecked_field('form_pets_cat')
+          @session.find(:label, 'Cat').click
+          expect(@session).to have_checked_field('form_pets_cat')
+          @session.find(:label, 'Cat').click
+          expect(@session).to have_unchecked_field('form_pets_cat')
+          @session.find(:label, 'McLaren').click
+          expect(@session).to have_checked_field('form_cars_mclaren', visible: :hidden)
+        end
+
+        it "should toggle the associated radio" do
+          @session.visit("/form")
+          expect(@session).to have_unchecked_field('gender_male')
+          @session.find(:label, 'Male').click
+          expect(@session).to have_checked_field('gender_male')
+          @session.find(:label, 'Female').click
+          expect(@session).to have_unchecked_field('gender_male')
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This will allow #check, #uncheck, #choose to click an associated label to toggle the checkbox/radio button state if the checkbox/radio button are not inter-actable (non-visible)