### PR TITLE
Fix Issue #1690 - within_Frame error with selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
-sudo: false
+dist: trusty
+sudo: required
 rvm:
   - 2.0.0
   - 2.2
-  - jruby-9.0.3.0
-  - rbx-2
+  - rbx-3.26
 gemfile:
   - Gemfile
 matrix:
@@ -14,8 +14,6 @@ matrix:
       env: WINDOW_TEST=true
     - gemfile: gemfiles/Gemfile.ruby-19
       rvm: 1.9.3
-    - gemfile: gemfiles/Gemfile.ruby-19
-      rvm: jruby-19mode
     - gemfile: gemfiles/Gemfile.base-versions
       rvm: 1.9.3
     - gemfile: gemfiles/Gemfile.beta-versions
@@ -25,7 +23,6 @@ matrix:
       env: CAPYBARA_CHROME=true
   allow_failures:
     - gemfile: gemfiles/Gemfile.beta-versions
-    - rvm: jruby-9.0.3.0
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+#Version 2.7.1
+Release date: Unreleased
+
+### Fixed
+* Issue where within_Frame would fail with Selenium if the frame is removed from within itself [Thomas Walpole]
+
 # Version 2.7.0
 Release date: 2016-04-07
 

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -143,23 +143,16 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   #
   def within_frame(frame_handle)
     frame_handle = frame_handle.native if frame_handle.is_a?(Capybara::Node::Base)
-    if !browser.switch_to.respond_to?(:parent_frame)
-      # Selenium Webdriver < 2.43 doesnt support moving back to the parent
-      @frame_handles[browser.window_handle] ||= []
-      @frame_handles[browser.window_handle] << frame_handle
-    end
+    @frame_handles[browser.window_handle] ||= []
+    @frame_handles[browser.window_handle] << frame_handle
     browser.switch_to.frame(frame_handle)
     yield
   ensure
-    if browser.switch_to.respond_to?(:parent_frame)
-      browser.switch_to.parent_frame
-    else
-      # There doesnt appear to be any way in Selenium Webdriver < 2.43 to move back to a parent frame
-      # other than going back to the root and then reiterating down
-      @frame_handles[browser.window_handle].pop
-      browser.switch_to.default_content
-      @frame_handles[browser.window_handle].each { |fh| browser.switch_to.frame(fh) }
-    end
+    # would love to use browser.switch_to.parent_frame here
+    # but it has an issue if the current frame is removed from within it
+    @frame_handles[browser.window_handle].pop
+    browser.switch_to.default_content
+    @frame_handles[browser.window_handle].each { |fh| browser.switch_to.frame(fh) }
   end
 
   def current_window_handle

--- a/lib/capybara/spec/session/within_frame_spec.rb
+++ b/lib/capybara/spec/session/within_frame_spec.rb
@@ -40,7 +40,7 @@ Capybara::SpecHelper.spec '#within_frame', :requires => [:frames] do
       @session.within_frame 'childFrame' do
         @session.within_frame 'grandchildFrame1' do end
         @session.within_frame 'grandchildFrame2' do end
-      end    
+      end
     end
   end
   it "should reset scope when changing frames" do
@@ -48,6 +48,16 @@ Capybara::SpecHelper.spec '#within_frame', :requires => [:frames] do
       @session.within_frame 'parentFrame' do
         expect(@session.has_selector?(:css, "iframe#childFrame")).to be true
       end
+    end
+  end
+
+  it "works if the frame is closed", :requires => [:frames, :js] do
+    @session.within_frame 'parentFrame' do
+      @session.within_frame 'childFrame' do
+        @session.click_link 'Close Window'
+      end
+      expect(@session).to have_selector(:css, 'body#parentBody')
+      expect(@session).not_to have_selector(:css, '#childFrame')
     end
   end
 end

--- a/lib/capybara/spec/views/frame_child.erb
+++ b/lib/capybara/spec/views/frame_child.erb
@@ -2,8 +2,15 @@
 <html>
     <head>
         <title>This is the child frame title</title>
+        <script>
+        function closeWin() {
+          var iframe = window.parent.document.getElementById('childFrame')
+          iframe.parentNode.removeChild(iframe)
+        }
+        </script>
     </head>
-    <body>
+    <body id="childBody">
+      <a href="javascript:void(0)" onClick="closeWin()">Close Window</a>
       <iframe src="/frame_one" id="grandchildFrame1"></iframe>
       <iframe src="/frame_two" id="grandchildFrame2"></iframe>
     </body>

--- a/lib/capybara/spec/views/frame_parent.erb
+++ b/lib/capybara/spec/views/frame_parent.erb
@@ -3,7 +3,7 @@
     <head>
         <title>This is the parent frame title</title>
     </head>
-    <body>
+    <body id="parentBody">
       <iframe src='/frame_child' id='childFrame'></iframe>
     </body>
 </html>


### PR DESCRIPTION
Calling switch_to.parent_frame to return from the current frame fails if the frame has been removed from inside itself.  Reverting to our previous method of storing the frame stack and then iterating back through it solves this.