### PR TITLE
reset sessions in reverse order so sessions with active servers are reset last

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ Release date: Unreleased
 
 ### Fixed
 * Issue where within_Frame would fail with Selenium if the frame is removed from within itself [Thomas Walpole]
+* Reset sessions in reverse order so sessions with active servers are reset last - Issue #1692 [Jonas Nicklas, Thomas Walpole]
 
 # Version 2.7.0
 Release date: 2016-04-07

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -327,7 +327,8 @@ module Capybara
     # as cookies.
     #
     def reset_sessions!
-      session_pool.each { |mode, session| session.reset! }
+      #reset in reverse so sessions that started servers are reset last
+      session_pool.reverse_each { |mode, session| session.reset! }
     end
     alias_method :reset!, :reset_sessions!
 


### PR DESCRIPTION
2.7 potential fix for Issue #1692 - Working on a better solution for 2.8