### PR TITLE
Handle open modals on session reset

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -92,39 +92,35 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   def reset!
     # Use instance variable directly so we avoid starting the browser just to reset the session
     if @browser
-      navigated = false
       start_time = Capybara::Helpers.monotonic_time
-      begin
-        if !navigated
-          # Only trigger a navigation if we haven't done it already, otherwise it
-          # can trigger an endless series of unload modals
-          begin
-            @browser.manage.delete_all_cookies
-          rescue Selenium::WebDriver::Error::UnhandledError
-            # delete_all_cookies fails when we've previously gone
-            # to about:blank, so we rescue this error and do nothing
-            # instead.
-          end
-          @browser.navigate.to("about:blank")
-        end
-        navigated = true
 
-        #Ensure the page is empty and trigger an UnhandledAlertError for any modals that appear during unload
-        until find_xpath("/html/body/*").empty? do
-          raise Capybara::ExpectationNotMet.new('Timed out waiting for Selenium session reset') if (Capybara::Helpers.monotonic_time - start_time) >= 10
-          sleep 0.05
+      begin
+        begin
+          @browser.manage.delete_all_cookies
+        rescue Selenium::WebDriver::Error::UnhandledError
+          # delete_all_cookies fails when we've previously gone
+          # to about:blank, so we rescue this error and do nothing
+          # instead.
+        end
+
+        if @browser.navigate.to("about:blank").to_s == ""
+          until find_xpath("/html/body/*").empty?
+            if (Capybara::Helpers.monotonic_time - start_time) >= 10
+              raise Capybara::ExpectationNotMet.new('Timed out waiting for Selenium session reset')
+            end
+
+            sleep 0.05
+          end
+        else
+          raise Selenium::WebDriver::Error::UnhandledAlertError
         end
       rescue Selenium::WebDriver::Error::UnhandledAlertError
-        # This error is thrown if an unhandled alert is on the page
-        # Firefox appears to automatically dismiss this alert, chrome does not
-        # We'll try to accept it
         begin
           @browser.switch_to.alert.accept
-          sleep 0.25 # allow time for the modal to be handled
         rescue Selenium::WebDriver::Error::NoAlertPresentError
-          # The alert is now gone - nothing to do
+          # There is no alert to close
         end
-        # try cleaning up the browser again
+
         retry
       end
     end

--- a/lib/capybara/spec/session/reset_session_spec.rb
+++ b/lib/capybara/spec/session/reset_session_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-Capybara::SpecHelper.spec '#reset_session!' do
+Capybara::SpecHelper.spec '#reset_session!', focus: true do
   it "removes cookies" do
     @session.visit('/set_cookie')
     @session.visit('/get_cookie')
@@ -42,6 +42,13 @@ Capybara::SpecHelper.spec '#reset_session!' do
   it "handles modals during unload" do
     @session.visit('/with_unload_alert')
     expect(@session).to have_selector(:css, 'div')
+    expect { @session.reset_session! }.not_to raise_error
+    expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
+  end
+
+  it "handles already open modals" do
+    @session.visit('/with_unload_alert')
+    @session.click_link('Go away')
     expect { @session.reset_session! }.not_to raise_error
     expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
   end

--- a/lib/capybara/spec/views/with_unload_alert.erb
+++ b/lib/capybara/spec/views/with_unload_alert.erb
@@ -8,5 +8,7 @@
 </head>
 <body>
   <div>This triggers an alert on unload</div>
+
+  <a href="/">Go away</a>
 </body>
 </html>


### PR DESCRIPTION
Unfortunately the current way of doing this is prone to race conditions. See #1696. Selenium does not provide any API to check if a modal is open, and simply trying to close it and catching the error is very, very slow on Firefox. One quirk though is that Selenium returns the text of any open modal as the return value of `navigate.to`. Why? I have no idea. Is this even an official/intentional API? I don't know. (Maybe @jarib knows?). So it turns out that the fastest way of safely navigating away from a page and catching any alerts caused by this is by checking that the return value of `navigate.to` is neither `""` nor `nil` (the behaviour seems to differ between selenium drivers). I've checked that this works with Chrome, Firefox and IE via the remote driver at least.

Honestly I'm not sure if this is the right way of solving this, but I'm kind of out of other ideas.