### PR TITLE
default selenium to raising an error when there are unexpected alerts

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -27,6 +27,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   def initialize(app, options={})
     begin
       require 'selenium-webdriver'
+      Selenium::WebDriver::Remote::Capabilities::DEFAULTS["unexpectedAlertBehaviour"] = "ignore"
     rescue LoadError => e
       if e.message =~ /selenium-webdriver/
         raise LoadError, "Capybara's selenium driver is unable to load `selenium-webdriver`, please install the gem and add `gem 'selenium-webdriver'` to your Gemfile if you are using bundler."

--- a/lib/capybara/spec/session/reset_session_spec.rb
+++ b/lib/capybara/spec/session/reset_session_spec.rb
@@ -46,6 +46,13 @@ Capybara::SpecHelper.spec '#reset_session!' do
     expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
   end
 
+  it "handles already open modals" do
+    @session.visit('/with_unload_alert')
+    @session.click_link('Go away')
+    expect { @session.reset_session! }.not_to raise_error
+    expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
+  end
+
   it "raises any standard errors caught inside the server", :requires => [:server] do
     quietly { @session.visit("/error") }
     expect do

--- a/lib/capybara/spec/views/with_unload_alert.erb
+++ b/lib/capybara/spec/views/with_unload_alert.erb
@@ -8,5 +8,7 @@
 </head>
 <body>
   <div>This triggers an alert on unload</div>
+
+  <a href="/">Go away</a>
 </body>
 </html>


### PR DESCRIPTION
Alternate to PR #1697  -  This changes selenium-webdriver to ignore unexpected alerts (raise an error) rather than the default of dismissing them which allows us to accept the alert from before unload and therefore allow unload to continue.