### PR TITLE
Change format session section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ GitHub): http://groups.google.com/group/ruby-capybara
 - [Asynchronous JavaScript (Ajax and friends)](#asynchronous-javascript-ajax-and-friends)
 - [Using the DSL elsewhere](#using-the-dsl-elsewhere)
 - [Calling remote servers](#calling-remote-servers)
-- [Named sessions](#named-sessions)
+- [Using sessions](#using-sessions)
 - [Using the sessions manually](#using-the-sessions-manually)
 - [XPath, CSS and selectors](#xpath-css-and-selectors)
 - [Beware the XPath // trap](#beware-the-xpath--trap)
@@ -819,11 +819,12 @@ remote application:
 Capybara.run_server = false
 ```
 
-## <a name="named-sessions"></a>Named sessions
+## <a name="using-sessions"></a>Using sessions
 
 Capybara manages named sessions (:default if not specified) and multiple sessions using the same driver and test app instance can be interacted with.
 A new session will be created using the current driver if a session with the given name using the current driver and test app instance is not found.
 
+### Named the sessions
 To perform operations in a different session and then revent to the previous session
 
 ```ruby
@@ -839,7 +840,7 @@ To permanently switch the current session to a different session
 Capybara.session_name = "some other session"
 ````
 
-## <a name="using-the-sessions-manually"></a>Using the sessions manually
+### <a name="using-the-sessions-manually"></a>Using the sessions manually
 
 For ultimate control, you can instantiate and use a
 [Session](http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Session)


### PR DESCRIPTION
Surrounding the `Named sessions` and `Using the sessions manually` section in `Using sessions`,
To make it easier to look for how Capybara managed sessions.