### PR TITLE
Add accessor for returning all sessions

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -324,6 +324,16 @@ module Capybara
 
     ##
     #
+    # All sessions that Capybara knows about, this does not include manually started sessions
+    #
+    # @return [Array<Capybara::Session>]     All known sessions
+    #
+    def all_sessions
+      session_pool.values
+    end
+
+    ##
+    #
     # Reset sessions, cleaning out the pool of sessions. This will remove any session information such
     # as cookies.
     #

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -196,6 +196,14 @@ RSpec.describe Capybara::DSL do
     end
   end
 
+  describe '#all_sessions' do
+    it "returns all sessions that Capybara knows about" do
+      this_session = Capybara.current_session
+      other_session = Capybara.using_session(:administrator) { Capybara.current_session }
+      expect(Capybara.all_sessions).to include(this_session, other_session)
+    end
+  end
+
   describe "#using_session" do
     it "should change the session name for the duration of the block" do
       expect(Capybara.session_name).to eq(:default)


### PR DESCRIPTION
This is occasionally useful.

For example in a recent application I'm using SauceLabs, and I'd like to iterate through all session in order to close them in a different way.