### PR TITLE
Add explanatory cause to re-raised server errors - Issue #1719

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@ Release date: Unreleased
 
 ### Fixed
 * Issue with modals present when closing the page using selenium - Issue #1696 [Jonas Nicklas, Thomas Walpole]
+* Server errors raised in test code have the cause set to an explanatory exception
+  in rubies that support Exception#cause rather than a confusing ExpectationNotMet - Issue #1719 [Thomas Walpole]
 
 ### Added
 * 'check', 'uncheck', and 'choose' will now click the associated label if the checkbox/radio button is not visible [Thomas Walpole]

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -120,7 +120,14 @@ module Capybara
     # Raise errors encountered in the server
     #
     def raise_server_error!
-      raise @server.error if Capybara.raise_server_errors and @server and @server.error
+      if Capybara.raise_server_errors and @server and @server.error
+        # Force an explanation for the error being raised as the exception cause
+        begin
+          raise CapybaraError, "Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true"
+        rescue CapybaraError
+          raise @server.error
+        end
+      end
     ensure
       @server.reset_error! if @server
     end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -408,6 +408,19 @@ Capybara::SpecHelper.spec "node" do
       end
     end
   end
+  
+  context "when #synchronize raises server errors" do
+    it "sets an explanatory exception as the cause of server exceptions", :requires => [:server, :js] do
+      skip "This version of ruby doesn't support exception causes" unless Exception.instance_methods.include? :cause
+      quietly { @session.visit("/error") }
+      expect do
+        @session.find(:css, 'span')
+      end.to raise_error(TestApp::TestAppError) do |e|
+        expect(e.cause).to be_a Capybara::CapybaraError 
+        expect(e.cause.message).to match /Your application server raised an error/
+      end
+    end
+  end
 
   def be_an_invalid_element_error(session)
     satisfy { |error| session.driver.invalid_element_errors.any? { |e| error.is_a? e } }


### PR DESCRIPTION
This fixes issue #1719 by making it clearer why server errors are appearing from test code.