### PR TITLE
Add support for RSpec 3.5+ shared_context_metadata_behavior == :apply_to_host_groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - gemfile: Gemfile
       rvm: 2.3.1
       env: WINDOW_TEST=true
-    - gemfile: Gemfile
+    - gemfile: gemfiles/Gemfile.rspec-34
       rvm: 2.3.1
       env: CAPYBARA_CHROME=true
     - gemfile: gemfiles/Gemfile.ruby-19

--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ Release date: Unreleased
 * Issue with modals present when closing the page using selenium - Issue #1696 [Jonas Nicklas, Thomas Walpole]
 * Server errors raised in test code have the cause set to an explanatory exception
   in rubies that support Exception#cause rather than a confusing ExpectationNotMet - Issue #1719 [Thomas Walpole]
+* background/given/given! RSoec aliases will work if RSpec config.shared_context_metadata_behavior == :apply_to_host_groups
 
 ### Added
 * 'check', 'uncheck', and 'choose' will now click the associated label if the checkbox/radio button is not visible [Thomas Walpole]

--- a/gemfiles/Gemfile.beta-versions
+++ b/gemfiles/Gemfile.beta-versions
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'bundler', '~> 1.0'
+gem 'bundler', '~> 1.1'
 gemspec :path => '..'
 
 gem 'xpath', github: 'jnicklas/xpath'

--- a/gemfiles/Gemfile.rspec-34
+++ b/gemfiles/Gemfile.rspec-34
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'bundler', '~> 1.1'
+gemspec :path => '..'
+
+gem 'xpath', github: 'jnicklas/xpath'
+gem 'rspec', '~>3.4.0'
+

--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 if RSpec::Core::Version::STRING.to_f >= 3.0
-  RSpec.shared_context "Capybara Features", :capybara_feature => true do
+  RSpec.shared_context "Capybara Features", capybara_feature: true do
     instance_eval do
       alias background before
       alias given let
@@ -8,13 +8,20 @@ if RSpec::Core::Version::STRING.to_f >= 3.0
     end
   end
 
+  # ensure shared_context is included if default shared_context_metadata_behavior is changed
+  if RSpec::Core::Version::STRING.to_f >= 3.5
+    RSpec.configure do |config|
+      config.include_context "Capybara Features", capybara_feature: true
+    end
+  end
+
   RSpec.configure do |config|
-    config.alias_example_group_to :feature, :capybara_feature => true, :type => :feature
-    config.alias_example_group_to :xfeature, :capybara_feature => true, :type => :feature, :skip => "Temporarily disabled with xfeature"
-    config.alias_example_group_to :ffeature, :capybara_feature => true, :type => :feature, :focus => true
+    config.alias_example_group_to :feature, capybara_feature: true, type: :feature
+    config.alias_example_group_to :xfeature, capybara_feature: true, type: :feature, skip: "Temporarily disabled with xfeature"
+    config.alias_example_group_to :ffeature, capybara_feature: true, type: :feature, focus: true
     config.alias_example_to :scenario
-    config.alias_example_to :xscenario, :skip => "Temporarily disabled with xscenario"
-    config.alias_example_to :fscenario, :focus => true
+    config.alias_example_to :xscenario, skip: "Temporarily disabled with xscenario"
+    config.alias_example_to :fscenario, focus: true
   end
 else
   module Capybara

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -22,6 +22,8 @@ module Capybara
         config.filter_run_excluding :requires => method(:filter).to_proc
         config.before { Capybara::SpecHelper.reset! }
         config.after { Capybara::SpecHelper.reset! }
+        # Test in 3.5+ where metadata doesn't autotrigger shared context inclusion - will be only behavior in RSpec 4
+        config.shared_context_metadata_behavior = :apply_to_host_groups if RSpec::Core::Version::STRING.to_f >= 3.5
       end
 
       def reset!

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -6,11 +6,11 @@ RSpec.configuration.before(:each, { file_path: "./spec/rspec/features_spec.rb" }
   @in_filtered_hook = true
 end
 
-feature "Capybara's feature DSL" do    
+feature "Capybara's feature DSL" do
   background do
     @in_background = true
   end
-  
+
   def current_example(context)
     RSpec.respond_to?(:current_example) ? RSpec.current_example : context.example
   end
@@ -20,7 +20,7 @@ feature "Capybara's feature DSL" do
     expect(page).to have_content('Hello world!')
   end
 
-  scenario "preserves description" do 
+  scenario "preserves description" do
     expect(current_example(self).metadata[:full_description])
       .to eq("Capybara's feature DSL preserves description")
   end


### PR DESCRIPTION
RSpec 3.5 added a new config.shared_context_metadata_behavior setting - http://rspec.info/blog/2016/07/rspec-3-5-has-been-released/ .  If this is set to `:apply_to_host_groups` the background/given/given! aliases will no longer be automatically included into features.  This PR fixes that issue.