### PR TITLE
Allow the `:with` option for the field selector to accept a regular expression

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,6 +15,7 @@ Release date: Unreleased
 * New frames API for drivers - Issue #1365 [Thomas Walpole]
 * Deprecated Element#parent in favor of Element#query_scope to better indicate what it is [Thomas Walpole]
 * Improved error messages for have_text matcher [Alex Chaffee, Thomas Walpole]
+* The `:with` option for the field selector now accepts a regular expression for matching the field value[Uwe Kubosch]
 
 #Version 2.7.1
 Release date: 2016-05-01

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -57,15 +57,15 @@ module Capybara
       #   @macro waiting_behavior
       #
       #
-      #   @option options [Boolean] checked  Match checked field?
-      #   @option options [Boolean] unchecked   Match unchecked field?
+      #   @option options [Boolean] checked       Match checked field?
+      #   @option options [Boolean] unchecked     Match unchecked field?
       #   @option options [Boolean, Symbol] disabled (false)  Match disabled field?
       #                                                       * true - only finds a disabled field
       #                                                       * false - only finds an enabled field
       #                                                       * :all - finds either an enabled or disabled field
-      #   @option options [Boolean] readonly Match readonly field?
-      #   @option options [String] with   Value of field to match on
-      #   @option options [String] type   Type of field to match on
+      #   @option options [Boolean] readonly      Match readonly field?
+      #   @option options [String, Regexp] with   Value of field to match on
+      #   @option options [String] type           Type of field to match on
       #   @option options [Boolean] multiple      Match fields that can have multiple values?
       #   @option options [String] id             Match fields that match the id attribute
       #   @option options [String] name           Match fields that match the name attribute

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -350,10 +350,10 @@ module Capybara
       #
       # Note: 'textarea' and 'select' are valid type values, matching the associated tag names.
       #
-      # @param [String] locator           The label, name or id of a field to check for
-      # @option options [String] :with    The text content of the field
-      # @option options [String] :type    The type attribute of the field
-      # @return [Boolean]                 Whether it exists
+      # @param [String] locator                  The label, name or id of a field to check for
+      # @option options [String, Regexp] :with   The text content of the field or a Regexp to match
+      # @option options [String] :type           The type attribute of the field
+      # @return [Boolean]                        Whether it exists
       #
       def has_field?(locator, options={})
         has_selector?(:field, locator, options)
@@ -364,10 +364,10 @@ module Capybara
       # Checks if the page or current node has no form field with the given
       # label, name or id. See {Capybara::Node::Matchers#has_field?}.
       #
-      # @param [String] locator           The label, name or id of a field to check for
-      # @option options [String] :with    The text content of the field
-      # @option options [String] :type    The type attribute of the field
-      # @return [Boolean]                 Whether it doesn't exist
+      # @param [String] locator                  The label, name or id of a field to check for
+      # @option options [String, Regexp] :with   The text content of the field or a Regexp to match
+      # @option options [String] :type           The type attribute of the field
+      # @return [Boolean]                        Whether it doesn't exist
       #
       def has_no_field?(locator, options={})
         has_no_selector?(:field, locator, options)

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -151,7 +151,9 @@ Capybara.add_selector(:field) do
   filter_set(:_field)
 
   filter(:readonly, boolean: true) { |node, value| not(value ^ node.readonly?) }
-  filter(:with) { |node, with| node.value == with.to_s }
+  filter(:with) do |node, with|
+    with.is_a?(Regexp) ? node.value =~ with : node.value == with.to_s
+  end
   filter(:type) do |node, type|
     if ['textarea', 'select'].include?(type)
       node.tag_name == type

--- a/lib/capybara/spec/session/has_field_spec.rb
+++ b/lib/capybara/spec/session/has_field_spec.rb
@@ -16,6 +16,7 @@ Capybara::SpecHelper.spec '#has_field' do
   context 'with value' do
     it "should be true if a field with the given value is on the page" do
       expect(@session).to have_field('First Name', :with => 'John')
+      expect(@session).to have_field('First Name', :with => /^Joh/)
       expect(@session).to have_field('Phone', :with => '+1 555 7021')
       expect(@session).to have_field('Street', :with => 'Sesame street 66')
       expect(@session).to have_field('Description', :with => 'Descriptive text goes here')
@@ -23,6 +24,7 @@ Capybara::SpecHelper.spec '#has_field' do
 
     it "should be false if the given field is not on the page" do
       expect(@session).not_to have_field('First Name', :with => 'Peter')
+      expect(@session).not_to have_field('First Name', :with => /eter$/)
       expect(@session).not_to have_field('Wrong Name', :with => 'John')
       expect(@session).not_to have_field('Description', :with => 'Monkey')
     end
@@ -30,11 +32,13 @@ Capybara::SpecHelper.spec '#has_field' do
     it "should be true after the field has been filled in with the given value" do
       @session.fill_in('First Name', :with => 'Jonas')
       expect(@session).to have_field('First Name', :with => 'Jonas')
+      expect(@session).to have_field('First Name', :with => /ona/)
     end
 
     it "should be false after the field has been filled in with a different value" do
       @session.fill_in('First Name', :with => 'Jonas')
       expect(@session).not_to have_field('First Name', :with => 'John')
+      expect(@session).not_to have_field('First Name', :with => /John|Paul|George|Ringo/)
     end
   end
 


### PR DESCRIPTION
I have come across several use cases where the field value is not completely predictable, but always follows a pattern.  It would be nice to be able to match the field value using a regular expression.

Please let me know how to improve this PR in any way.

I could not find any direct documentation of the field selector options.  Let me know if there is documentation i should update.

This PR is based off the current master and has the same failure on travis as master.  I have expanded the tests for the new feature.