### PR TITLE
Allow to use text as invalid Regexp for `#have_text`

### DIFF
--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -48,7 +48,7 @@ module Capybara
         details_message = []
 
         if @node and !@expected_text.is_a? Regexp
-          insensitive_regexp = Regexp.new(@expected_text, Regexp::IGNORECASE)
+          insensitive_regexp = Regexp.new(Regexp.escape(@expected_text), Regexp::IGNORECASE)
           insensitive_count = @actual_text.scan(insensitive_regexp).size
           if insensitive_count != @count
             details_message << "it was found #{insensitive_count} #{Capybara::Helpers.declension("time", "times", insensitive_count)} using a case insensitive search"

--- a/lib/capybara/spec/session/assert_text.rb
+++ b/lib/capybara/spec/session/assert_text.rb
@@ -50,6 +50,9 @@ Capybara::SpecHelper.spec '#assert_text' do
     expect do
       @session.assert_text('Text With Whitespace')
     end.to raise_error(Capybara::ExpectationNotMet, /it was found 1 time using a case insensitive search/)
+    expect do
+      @session.assert_text('[]')
+    end.to raise_error(Capybara::ExpectationNotMet, /expected to find text "\[\]"/)
   end
 
   it "should be true if the text in the page matches given regexp" do


### PR DESCRIPTION
When the text as invalid Regexp is given to `#have_text`, it raises the following error:
``` ruby
expect(page).to have_text('[]') #=> RegexpError: empty char-class: /[]/
```

We expect an error `Capybara::ExpectationNotMet`, not a `RegexpError`.