### PR TITLE
Fix issue with error message when expected text is missing but contains regex special characters

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+#Version 2.8.1
+Release data: unreleased
+
+###Fixed
+* Fixed error message from have_text when text is not found but contains regex special characters [Ryunosuke Sato]
+
 # Version 2.8.0
 Release date: 2016-08-16
 

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -48,7 +48,7 @@ module Capybara
         details_message = []
 
         if @node and !@expected_text.is_a? Regexp
-          insensitive_regexp = Regexp.new(Regexp.escape(@expected_text), Regexp::IGNORECASE)
+          insensitive_regexp = Capybara::Helpers.to_regexp(@expected_text, Regexp::IGNORECASE)
           insensitive_count = @actual_text.scan(insensitive_regexp).size
           if insensitive_count != @count
             details_message << "it was found #{insensitive_count} #{Capybara::Helpers.declension("time", "times", insensitive_count)} using a case insensitive search"

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -48,7 +48,7 @@ module Capybara
         details_message = []
 
         if @node and !@expected_text.is_a? Regexp
-          insensitive_regexp = Regexp.new(@expected_text, Regexp::IGNORECASE)
+          insensitive_regexp = Regexp.new(Regexp.escape(@expected_text), Regexp::IGNORECASE)
           insensitive_count = @actual_text.scan(insensitive_regexp).size
           if insensitive_count != @count
             details_message << "it was found #{insensitive_count} #{Capybara::Helpers.declension("time", "times", insensitive_count)} using a case insensitive search"

--- a/lib/capybara/spec/session/assert_text.rb
+++ b/lib/capybara/spec/session/assert_text.rb
@@ -50,6 +50,9 @@ Capybara::SpecHelper.spec '#assert_text' do
     expect do
       @session.assert_text('Text With Whitespace')
     end.to raise_error(Capybara::ExpectationNotMet, /it was found 1 time using a case insensitive search/)
+    expect do
+      @session.assert_text('[]')
+    end.to raise_error(Capybara::ExpectationNotMet, /expected to find text "\[\]"/)
   end
 
   it "should be true if the text in the page matches given regexp" do

--- a/lib/capybara/spec/session/assert_text.rb
+++ b/lib/capybara/spec/session/assert_text.rb
@@ -50,9 +50,13 @@ Capybara::SpecHelper.spec '#assert_text' do
     expect do
       @session.assert_text('Text With Whitespace')
     end.to raise_error(Capybara::ExpectationNotMet, /it was found 1 time using a case insensitive search/)
+  end
+
+  it "should raise the correct error if requested text is missing but contains regex special characters" do
+    @session.visit('/with_html')
     expect do
-      @session.assert_text('[]')
-    end.to raise_error(Capybara::ExpectationNotMet, /expected to find text "\[\]"/)
+      @session.assert_text('[]*.')
+    end.to raise_error(Capybara::ExpectationNotMet, /expected to find text "\[\]\*\."/)
   end
 
   it "should be true if the text in the page matches given regexp" do


### PR DESCRIPTION
Fix issue with error message when expected text is missing but contains regex special characters