### PR TITLE
clarify Firefox note on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ through an external gem.
 **Need help?** Ask on the mailing list (please do not open an issue on
 GitHub): http://groups.google.com/group/ruby-capybara
 
-**Note: Firefox 48** If you're using Firefox with selenium-webdrvier, stay on Firefox 47.0.1 and selenium-webdriver 2.53.4.  Firefox 48 requires geckodriver and is not supported without selenium-webdriver 3 which currently has multiple issues and is feature incomplete
+**Note: Firefox 48** If you're using Firefox with selenium-webdriver, 
+it is recommended that you use [Firefox ESR](https://www.mozilla.org/en-US/firefox/organizations/)
+or Firefox 47.0.1. Firefox 48+ requires [geckodriver](https://github.com/mozilla/geckodriver/releases). 
+To [use geckodriver in Selenium 2](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver#Ruby_3), 
+you can register a driver with a desired capability of `marionette: true`. This is set to true by
+default in Selenium 3, so to use the legacy Firefox driver, register a driver with a desired capability of `marionette: false`.
+Geckodriver still has multiple issues and is feature incomplete.
 
 ## Table of contents
 


### PR DESCRIPTION
The current statement in the README is technically incorrect.

This is the code that should work to use Selenium 3.0 with the legacy Firefox driver.
```ruby
Capybara.register_driver :legacy_firefox do |app|
  Capybara::Selenium::Driver.new(
    app,
    browser: :firefox,
    desired_capabilities: Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false)
  )
end
```

If this PR is too wordy, maybe the information and above code could be put somewhere else and referenced by link in the README.