### PR TITLE
move helpers to BaseQuery

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -53,65 +53,6 @@ module Capybara
 
     ##
     #
-    # Checks if the given count matches the given count options.
-    # Defaults to true if no options are specified. If multiple
-    # options are provided, it tests that all conditions are met;
-    # however, if :count is supplied, all other options are ignored.
-    #
-    # @param [Integer] count     The actual number. Should be coercible via Integer()
-    # @option [Range] between    Count must be within the given range
-    # @option [Integer] count    Count must be exactly this
-    # @option [Integer] maximum  Count must be smaller than or equal to this value
-    # @option [Integer] minimum  Count must be larger than or equal to this value
-    #
-    def matches_count?(count, options={})
-      return (Integer(options[:count]) == count)     if options[:count]
-      return false if options[:maximum] && (Integer(options[:maximum]) < count)
-      return false if options[:minimum] && (Integer(options[:minimum]) > count)
-      return false if options[:between] && !(options[:between] === count)
-      return true
-    end
-
-    ##
-    #
-    # Checks if a count of 0 is valid for the given options hash.
-    # Returns false if options hash does not specify any count options.
-    #
-    def expects_none?(options={})
-      if [:count, :maximum, :minimum, :between].any? { |k| options.has_key? k }
-        matches_count?(0,options)
-      else
-        false
-      end
-    end
-
-    ##
-    #
-    # Generates a failure message given a description of the query and count
-    # options.
-    #
-    # @param [String] description   Description of a query
-    # @option [Range] between       Count should have been within the given range
-    # @option [Integer] count       Count should have been exactly this
-    # @option [Integer] maximum     Count should have been smaller than or equal to this value
-    # @option [Integer] minimum     Count should have been larger than or equal to this value
-    #
-    def failure_message(description, options={})
-      message = String.new("expected to find #{description}")
-      if options[:count]
-        message << " #{options[:count]} #{declension('time', 'times', options[:count])}"
-      elsif options[:between]
-        message << " between #{options[:between].first} and #{options[:between].last} times"
-      elsif options[:maximum]
-        message << " at most #{options[:maximum]} #{declension('time', 'times', options[:maximum])}"
-      elsif options[:minimum]
-        message << " at least #{options[:minimum]} #{declension('time', 'times', options[:minimum])}"
-      end
-      message
-    end
-
-    ##
-    #
     # A poor man's `pluralize`. Given two declensions, one singular and one
     # plural, as well as a count, this will pick the correct declension. This
     # way we can generate grammatically correct error message.

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -123,7 +123,7 @@ module Capybara
         query = Capybara::Queries::SelectorQuery.new(*args)
         synchronize(query.wait) do
           result = query.resolve_for(self)
-          unless result.matches_count? && ((!result.empty?) || Capybara::Helpers.expects_none?(query.options))
+          unless result.matches_count? && ((!result.empty?) || query.expects_none?)
             raise Capybara::ExpectationNotMet, result.failure_message
           end
         end
@@ -150,7 +150,7 @@ module Capybara
         query = Capybara::Queries::SelectorQuery.new(*args)
         synchronize(query.wait) do
           result = query.resolve_for(self)
-          if result.matches_count? && ((!result.empty?) || Capybara::Helpers.expects_none?(query.options))
+          if result.matches_count? && ((!result.empty?) || query.expects_none?)
             raise Capybara::ExpectationNotMet, result.negative_failure_message
           end
         end
@@ -520,8 +520,7 @@ module Capybara
         query = Capybara::Queries::TextQuery.new(*args)
         synchronize(query.wait) do
           count = query.resolve_for(self)
-          matches_count = Capybara::Helpers.matches_count?(count, query.options)
-          unless matches_count && ((count > 0) || Capybara::Helpers.expects_none?(query.options))
+          unless query.matches_count?(count) && ((count > 0) || query.expects_none?)
             raise Capybara::ExpectationNotMet, query.failure_message
           end
         end
@@ -540,8 +539,7 @@ module Capybara
         query = Capybara::Queries::TextQuery.new(*args)
         synchronize(query.wait) do
           count = query.resolve_for(self)
-          matches_count = Capybara::Helpers.matches_count?(count, query.options)
-          if matches_count && ((count > 0) || Capybara::Helpers.expects_none?(query.options))
+          if query.matches_count?(count) && ((count > 0) || query.expects_none?)
             raise Capybara::ExpectationNotMet, query.negative_failure_message
           end
         end

--- a/lib/capybara/queries/base_query.rb
+++ b/lib/capybara/queries/base_query.rb
@@ -15,7 +15,63 @@ module Capybara
         options.fetch(:wait, Capybara.default_max_wait_time) || 0
       end
 
+      ##
+      #
+      # Checks if a count of 0 is valid for the query
+      # Returns false if query does not have any count options specified.
+      #
+      def expects_none?
+        if COUNT_KEYS.any? { |k| options.has_key? k }
+          matches_count?(0)
+        else
+          false
+        end
+      end
+
+      ##
+      #
+      # Checks if the given count matches the query count options.
+      # Defaults to true if no count options are specified. If multiple
+      # count options exist, it tests that all conditions are met;
+      # however, if :count is specified, all other options are ignored.
+      #
+      # @param [Integer] count     The actual number. Should be coercible via Integer()
+      #
+      def matches_count?(count)
+        return (Integer(options[:count]) == count)     if options[:count]
+        return false if options[:maximum] && (Integer(options[:maximum]) < count)
+        return false if options[:minimum] && (Integer(options[:minimum]) > count)
+        return false if options[:between] && !(options[:between] === count)
+        return true
+      end
+
+      ##
+      #
+      # Generates a failure message from the query description and count options.
+      #
+      def failure_message
+        String.new("expected to find #{description}") << count_message
+      end
+
+      def negative_failure_message
+        String.new("expected not to find #{description}") << count_message
+      end
+
       private
+
+      def count_message
+        message = String.new()
+        if options[:count]
+          message << " #{options[:count]} #{Capybara::Helpers.declension('time', 'times', options[:count])}"
+        elsif options[:between]
+          message << " between #{options[:between].first} and #{options[:between].last} times"
+        elsif options[:maximum]
+          message << " at most #{options[:maximum]} #{Capybara::Helpers.declension('time', 'times', options[:maximum])}"
+        elsif options[:minimum]
+          message << " at least #{options[:minimum]} #{Capybara::Helpers.declension('time', 'times', options[:minimum])}"
+        end
+        message
+      end
 
       def assert_valid_keys
         invalid_keys = @options.keys - valid_keys

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -22,24 +22,25 @@ module Capybara
       end
 
       def failure_message
-        build_message(true)
+        super << build_message(true)
       end
 
       def negative_failure_message
-        build_message(false).sub(/(to find)/, 'not \1')
+        super << build_message(false)
+      end
+
+      def description
+        if @expected_text.is_a?(Regexp)
+          "text matching #{@expected_text.inspect}"
+        else
+          "text #{@expected_text.inspect}"
+        end
       end
 
       private
 
       def build_message(report_on_invisible)
-        description =
-          if @expected_text.is_a?(Regexp)
-            "text matching #{@expected_text.inspect}"
-          else
-            "text #{@expected_text.inspect}"
-          end
-
-        message = Capybara::Helpers.failure_message(description, @options)
+        message = String.new()
         unless (COUNT_KEYS & @options.keys).empty?
           message << " but found #{@count} #{Capybara::Helpers.declension('time', 'times', @count)}"
         end

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -85,7 +85,7 @@ module Capybara
     end
 
     def failure_message
-      message = Capybara::Helpers.failure_message(@query.description, @query.options)
+      message = @query.failure_message
       if count > 0
         message << ", found #{count} #{Capybara::Helpers.declension("match", "matches", count)}: " << full_results.map(&:text).map(&:inspect).join(", ")
       else


### PR DESCRIPTION
Move some helper methods into BaseQuery - the helpers are marked as api private so should be ok to move in a minor version release