### PR TITLE
Work around mime-types broken sorting on MIME::Types.type_for('xxx.csv')

### DIFF
--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -42,7 +42,8 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
               if (value = field['value']).to_s.empty?
                 NilUploadedFile.new
               else
-                content_type = MIME::Types.type_for(value).first.to_s
+                types = MIME::Types.type_for(value)
+                content_type = types.sort_by.with_index { |type, idx| [type.obsolete? ? 1 : 0, idx] }.first.to_s
                 Rack::Test::UploadedFile.new(value, content_type)
               end
             merge_param!(params, field['name'].to_s, file)

--- a/spec/fixtures/capybara.csv
+++ b/spec/fixtures/capybara.csv
@@ -1,0 +1,1 @@
+test, mime-type, file

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Capybara::Session do
           expect(@session.html).to include('Successfully ignored empty file field.')
         end
       end
+
+      it "should not submit an obsolete mime type" do
+        @test_jpg_file_path = File.expand_path('fixtures/capybara.csv', File.dirname(__FILE__))
+        @session.visit("/form")
+        @session.attach_file "form_document", @test_jpg_file_path
+        @session.click_button('Upload Single')
+        expect(@session).to have_content("Content-type: text/csv")
+      end
     end
 
     describe "#click" do


### PR DESCRIPTION
MIME::Types.type_for('xxx.csv') returns an obsolete type first, which is not how the docs describe - http://www.rubydoc.info/gems/mime-types/MIME/Types#type_for-instance_method .  According to the docs they should be in priority order with non-obsolete types before obsolete types.  This works around that issue.  - Issue #1756