### PR TITLE
Select button element by descendant image alt text

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+#Edge
+
+### Changed
+* Select `<button>` elements with descendant images with `alt` attributes matching the locator [Ian Lesperance]
+
 #Version 2.9.2
 Release date: 2016-09-29
 

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -157,7 +157,7 @@ end
 #
 #  Find buttons ( input [of type submit, reset, image, button] or button elements )
 #
-# @locator Matches the id, value, or title attributes, string content of a button, or the alt attribute of an image type button
+# @locator Matches the id, value, or title attributes, string content of a button, or the alt attribute of an image type button or of a descendant image of a button
 #
 # @filter [String] :id  Matches the id attribute
 # @filter [String] :title Matches the title attribute
@@ -177,7 +177,7 @@ Capybara.add_selector(:button) do
 
       input_btn_xpath = input_btn_xpath[locator_matches]
 
-      btn_xpath = btn_xpath[locator_matches | XPath.string.n.is(locator)]
+      btn_xpath = btn_xpath[locator_matches | XPath.string.n.is(locator) | XPath.descendant(:img)[XPath.attr(:alt).is(locator)]]
 
       alt_matches = XPath.attr(:alt).is(locator)
       alt_matches |= XPath.attr(:'aria-label').is(locator) if Capybara.enable_aria_label

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -338,6 +338,19 @@ Capybara::SpecHelper.spec '#click_button' do
       expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
+
+  context "with descendant image alt given on a button defined by <button> tag" do
+    it "should submit the associated form" do
+      @session.click_button('A horse eating hay')
+      expect(extract_results(@session)['first_name']).to eq('John')
+    end
+
+    it "should work with partial matches" do
+      @session.click_button('se eating h')
+      expect(extract_results(@session)['first_name']).to eq('John')
+    end
+  end
+
   context "with a locator that doesn't exist" do
     it "should raise an error" do
       msg = "Unable to find button \"does not exist\""

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -351,6 +351,7 @@ New line after and before textarea tag
     <button type="submit" id="click_me_123" title="Click Title button" value="click_me">Click me!</button>
     <button type="submit" name="form[no_value]">No Value!</button>
     <button id="no_type">No Type!</button>
+    <button><img alt="A horse eating hay"/></button>
     <input type="button" disabled="disabled" value="Disabled button"/>
   </p>
 


### PR DESCRIPTION
As with links, button elements may consistent entirely of an image. In such cases, one may identify the button using the value of the descendant image's alt attribute (as a screen reader would).