### PR TITLE
Allow a selector to specify its default visibility setting

### DIFF
--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -76,18 +76,10 @@ module Capybara
       end
 
       def visible
-        if options.has_key?(:visible)
-          case @options[:visible]
-            when true then :visible
-            when false then :all
-            else @options[:visible]
-          end
-        else
-          if Capybara.ignore_hidden_elements
-            :visible
-          else
-            :all
-          end
+        case (vis = options.fetch(:visible){ @selector.default_visibility })
+          when true then :visible
+          when false then :all
+          else vis
         end
       end
 

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -50,6 +50,7 @@ module Capybara
       @format = nil
       @expression = nil
       @expression_filters = []
+      @default_visibility = nil
       instance_eval(&block)
     end
 
@@ -184,6 +185,27 @@ module Capybara
 
     def describe &block
       @filter_set.describe &block
+    end
+
+    ##
+    #
+    # Set the default visibility mode that shouble be used if no visibile option is passed when using the selector.
+    # If not specified will default to the behavior indicated by Capybara.ignore_hidden_elements
+    #
+    # @param [Symbol] default_visibility  Only find elements with the specified visibility:
+    #                                              * :all - finds visible and invisible elements.
+    #                                              * :hidden - only finds invisible elements.
+    #                                              * :visible - only finds visible elements.
+    def visible(default_visibility)
+      @default_visibility = default_visibility
+    end
+
+    def default_visibility
+      if @default_visibility.nil?
+        Capybara.ignore_hidden_elements
+      else
+        @default_visibility
+      end
     end
 
     private

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Capybara do
             <label for="my_text_input">My Text Input</label>
             <input type="text" name="form[my_text_input]" placeholder="my text" id="my_text_input"/>
             <input type="file" id="file" class=".special file"/>
+            <input type="hidden" id="hidden_field" value="this is hidden"/>
             <a href="#">link</a>
             <fieldset></fieldset>
             <select>
@@ -48,6 +49,18 @@ RSpec.describe Capybara do
 
       Capybara.add_selector :custom_css_selector do
         css { |selector| selector }
+      end
+    end
+
+    describe "adding a selector" do
+      it "can set default visiblity" do
+        Capybara.add_selector :hidden_field do
+          visible :hidden
+          css { |sel| 'input[type="hidden"]' }
+        end
+
+        expect(string).to have_no_css('input[type="hidden"]')
+        expect(string).to have_selector(:hidden_field)
       end
     end
 


### PR DESCRIPTION
This allows for a selector to have a default visibility setting.  This means a custom selector written to find input elements of type = "hidden" won't need to specify visible: false in the options every time it's used when it would only ever make sense to use the selector if visible: false/:all/:hidden was specified.

    Capybara.add_selector(:hidden_field,) do
      visible :hidden
      css { |s| 'input[type="hidden"]' }
    end

without the visibility setting this would have to be used like

    page.find(:hidden_field, visible: false)  # annoying since it can only work with visible: false/:all/:hidden

with the setting it can just be

    page.find(:hidden_field)
