### PR TITLE
JRuby updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 rvm:
   - 2.0.0
   - 2.2
-  - jruby-9.0.5.0
+  - jruby-9.1.5.0
   - rbx-3.26
 gemfile:
   - Gemfile
@@ -50,11 +50,12 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.beta-versions
     - gemfile: gemfiles/Gemfile.beta-marionette
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.5.0
     - rvm: rbx-3.26
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - JAVA_OPTS=-Djava.security.egd=file:/dev/urandom
 
 addons:
   firefox: 47.0.1

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -28,6 +28,11 @@ module Capybara
       @result_cache = []
       @results_enum = lazy_select_elements { |node| query.matches_filters?(node) }
       @query = query
+      # JRuby has an issue with eagerly finding next in lazy enumerators which
+      # causes a concurrency issue with network requests here
+      # https://github.com/jruby/jruby/issues/4212
+      # Just force all the results to be evaluated
+      full_results if RUBY_PLATFORM == 'java'
     end
 
     def_delegators :full_results, :size, :length, :last, :values_at, :inspect, :sample

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -345,6 +345,7 @@ Capybara.add_selector(:select) do
     end
     options.sort == actual.sort
   end
+
   filter(:with_options) do |node, options|
     finder_settings = { minimum: 0 }
     if !node.visible?
@@ -352,6 +353,7 @@ Capybara.add_selector(:select) do
     end
     options.all? { |option| node.first(:option, option, finder_settings) }
   end
+
   filter(:selected) do |node, selected|
     actual = node.all(:xpath, './/option', visible: false).select { |option| option.selected? }.map { |option| option.text(:all) }
     [selected].flatten.sort == actual.sort

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -2,6 +2,7 @@
 require "uri"
 
 class Capybara::Selenium::Driver < Capybara::Driver::Base
+
   DEFAULT_OPTIONS = {
     :browser => :firefox
   }
@@ -39,6 +40,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         raise e
       end
     end
+
 
     @app = app
     @browser = nil

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -125,7 +125,7 @@ module Capybara
         begin
           raise CapybaraError, "Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true"
         rescue CapybaraError
-          raise @server.error
+          raise @server.error.class, @server.error.message, @server.error.backtrace
         end
       end
     ensure

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Capybara::Result do
 
   #Not a great test but it indirectly tests what is needed
   it "should evaluate filters lazily" do
+    skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java'
     #Not processed until accessed
     expect(result.instance_variable_get('@result_cache').size).to be 0
 


### PR DESCRIPTION
Update Travis to use /dev/urandom when installing JRuby to work around the lack of entropy in /dev/random.

Change how app exceptions are raised from tests so the cause is properly set in JRuby

Disable Capybara::Result element evaluation optimization when using JRuby due to a bug in lazy enumerator evaluation - https://github.com/jruby/jruby/issues/4212