### PR TITLE
Define the return type for actions where not otherwise defined

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -18,6 +18,8 @@ module Capybara
       #
       #   @param [String] locator      Text, id or value of link or button
       #
+      # @return [Capybara::Node::Element]  The element clicked
+      #
       def click_link_or_button(locator=nil, options={})
         locator, options = nil, locator if locator.is_a? Hash
         find(:link_or_button, locator, options).click
@@ -35,6 +37,7 @@ module Capybara
       #   @param [String] locator         text, id, title or nested image's alt attribute
       #   @param options                  See {Capybara::Node::Finders#find_link}
       #
+      # @return [Capybara::Node::Element]  The element clicked
       def click_link(locator=nil, options={})
         locator, options = nil, locator if locator.is_a? Hash
         find(:link, locator, options).click
@@ -52,6 +55,7 @@ module Capybara
       # @overload click_button([locator], options)
       #   @param [String] locator      Which button to find
       #   @param options     See {Capybara::Node::Finders#find_button}
+      # @return [Capybara::Node::Element]  The element clicked
       def click_button(locator=nil, options={})
         locator, options = nil, locator if locator.is_a? Hash
         find(:button, locator, options).click
@@ -77,6 +81,7 @@ module Capybara
       #   @option options [String] :placeholder    Match fields that match the placeholder attribute
       #   @option options [String, Array<String>] :class    Match links that match the class(es) provided
       #
+      # @return [Capybara::Node::Element]  The element filled_in
       def fill_in(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
         raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
@@ -104,6 +109,8 @@ module Capybara
       #   @option options [String, Array<String>] :class    Match links that match the class(es) provided
       #   @macro waiting_behavior
       #   @macro label_click
+      #
+      # @return [Capybara::Node::Element]  The element chosen or the label clicked
       def choose(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
         allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
@@ -141,6 +148,7 @@ module Capybara
       #   @macro label_click
       #   @macro waiting_behavior
       #
+      # @return [Capybara::Node::Element]  The element checked or the label clicked
       def check(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
         allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
@@ -178,6 +186,7 @@ module Capybara
       #   @macro label_click
       #   @macro waiting_behavior
       #
+      # @return [Capybara::Node::Element]  The element unchecked or the label clicked
       def uncheck(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
         allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
@@ -213,6 +222,7 @@ module Capybara
       # @param [String] value                   Which option to select
       # @option options [String] :from  The id, name or label of the select box
       #
+      # @return [Capybara::Node::Element]  The option element selected
       def select(value, options={})
         if options.has_key?(:from)
           from = options.delete(:from)
@@ -235,6 +245,7 @@ module Capybara
       # @param [String] value                   Which option to unselect
       # @param [Hash{:from => String}] options  The id, name or label of the select box
       #
+      # @return [Capybara::Node::Element]  The option element unselected
       def unselect(value, options={})
         if options.has_key?(:from)
           from = options.delete(:from)
@@ -263,6 +274,7 @@ module Capybara
       # @option options [String] name           Match fields that match the name attribute
       # @option options [String, Array<String>] :class    Match links that match the class(es) provided
       #
+      # @return [Capybara::Node::Element]  The file field element
       def attach_file(locator, path, options={})
         locator, path, options = nil, locator, path if path.is_a? Hash
         Array(path).each do |p|

--- a/lib/capybara/node/document.rb
+++ b/lib/capybara/node/document.rb
@@ -24,6 +24,10 @@ module Capybara
         find(:xpath, '/html').text(type)
       end
 
+      ##
+      #
+      # @return [String]    The title of the document
+      #
       def title
         session.driver.title
       end

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -92,6 +92,7 @@ module Capybara
       # @param [String] value    The new value
       # @param [Hash{}] options  Driver specific options for how to set the value
       #
+      # @return [Capybara::Node::Element]  The element
       def set(value, options={})
         options ||= {}
 
@@ -108,47 +109,58 @@ module Capybara
             base.set(value)
           end
         end
+        return self
       end
 
       ##
       #
       # Select this node if is an option element inside a select tag
       #
+      # @return [Capybara::Node::Element]  The element
       def select_option
         warn "Attempt to select disabled option: #{value || text}" if disabled?
         synchronize { base.select_option }
+        return self
       end
 
       ##
       #
       # Unselect this node if is an option element inside a multiple select tag
       #
+      # @return [Capybara::Node::Element]  The element
       def unselect_option
         synchronize { base.unselect_option }
+        return self
       end
 
       ##
       #
       # Click the Element
       #
+      # @return [Capybara::Node::Element]  The element
       def click
         synchronize { base.click }
+        return self
       end
 
       ##
       #
       # Right Click the Element
       #
+      # @return [Capybara::Node::Element]  The element
       def right_click
         synchronize { base.right_click }
+        return self
       end
 
       ##
       #
       # Double Click the Element
       #
+      # @return [Capybara::Node::Element]  The element
       def double_click
         synchronize { base.double_click }
+        return self
       end
 
       ##
@@ -221,16 +233,20 @@ module Capybara
       # :meta
       # :command      - alias of :meta
       #
+      # @return [Capybara::Node::Element]  The element
       def send_keys(*args)
         synchronize { base.send_keys(*args) }
+        return self
       end
 
       ##
       #
       # Hover on the Element
       #
+      # @return [Capybara::Node::Element]  The element
       def hover
         synchronize { base.hover }
+        return self
       end
 
       ##
@@ -319,8 +335,10 @@ module Capybara
       #
       # @param [String] event       The name of the event to trigger
       #
+      # @return [Capybara::Node::Element]  The element
       def trigger(event)
         synchronize { base.trigger(event) }
+        return self
       end
 
       ##
@@ -333,8 +351,10 @@ module Capybara
       #
       # @param [Capybara::Node::Element] node     The element to drag to
       #
+      # @return [Capybara::Node::Element]  The element
       def drag_to(node)
         synchronize { base.drag_to(node.base) }
+        return self
       end
 
       def reload

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -148,6 +148,9 @@ module Capybara
         # no op
       end
 
+      ##
+      #
+      # @return [String]     The title of the document
       def title
         if native.respond_to? :title
           native.title

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -86,4 +86,9 @@ Capybara::SpecHelper.spec "#choose" do
       end
     end
   end
+
+  it "should return the chosen radio button" do
+    el = @session.find(:radio_button, 'gender_male')
+    expect(@session.choose("gender_male")).to eq el
+  end
 end

--- a/lib/capybara/spec/session/click_link_or_button_spec.rb
+++ b/lib/capybara/spec/session/click_link_or_button_spec.rb
@@ -108,6 +108,11 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
         @session.click_link_or_button('Disabled button', disabled: false)
       end.to raise_error(Capybara::ElementNotFound)
     end
+  end
 
+  it "should return the element clicked" do
+    @session.visit('/with_html')
+    link = @session.find(:link, 'labore')
+    expect(@session.click_link_or_button('labore')).to eq link
   end
 end

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -186,4 +186,9 @@ Capybara::SpecHelper.spec '#click_link' do
       expect(@session).to have_content('Another World')
     end
   end
+
+  it "should return element clicked", twtw: true do
+    el = @session.find(:link, 'Normal Anchor')
+    expect(@session.click_link('Normal Anchor')).to eq el
+  end
 end

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -181,4 +181,9 @@ Capybara::SpecHelper.spec "#fill_in" do
       end.to raise_error(Capybara::ElementNotFound)
     end
   end
+
+  it "should return the element filled in" do
+    el = @session.find(:fillable_field, 'form_first_name')
+    expect(@session.fill_in('form_first_name', with: 'Harry')).to eq el
+  end
 end


### PR DESCRIPTION
This defines the return type for node actions not otherwise defined as being the element being interacted with.  This allows for chaining some actions on elements, or checking their state, etc.

    element.click.send_keys(....)
    element.click.selected?

