### PR TITLE
Catch error for a dead remote connection upon quit

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -242,6 +242,8 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     @browser.quit if @browser
   rescue Errno::ECONNREFUSED
     # Browser must have already gone
+  rescue Selenium::WebDriver::Error::UnknownError
+    # Browser must have already disconnected
   ensure
     @browser = nil
   end


### PR DESCRIPTION
Potential solution for #1773.

Upon quitting the browser, this catches a `Selenium::WebDriver::Error::UnknownError` exception, which is raised when there is a server-side issue communicating with the browser.

If the remote browser session is terminated for a server-side reason, Capybara will be able to assign `@browser` to nil upon quitting.