### PR TITLE
ignore another error while quitting selenium-webdriver

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+#Edge
+Release data: unreleased
+
+### Fixed
+* Ignore specific error when qutting selenium driver instance - Issue #1773 [Dylan Reichstadt\, Thomas Walpole]
+
 #2.10.1
 Release date: 2016-10-08
 

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -242,6 +242,9 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     @browser.quit if @browser
   rescue Errno::ECONNREFUSED
     # Browser must have already gone
+  rescue Selenium::WebDriver::Error::UnknownError => e
+    raise unless e.message =~ /Error communicating with the remote browser/
+    # probably already gone
   ensure
     @browser = nil
   end


### PR DESCRIPTION
PR #1774 But checking for a specific message in the exception to limit the number of errors ignored