### PR TITLE
optional clearing of local/session storage for selenium driver

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -4,9 +4,11 @@ require "uri"
 class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   DEFAULT_OPTIONS = {
-    :browser => :firefox
+    :browser => :firefox,
+    clear_local_storage: false,
+    clear_session_storage: false
   }
-  SPECIAL_OPTIONS = [:browser]
+  SPECIAL_OPTIONS = [:browser, :clear_local_storage, :clear_session_storage]
 
   attr_reader :app, :options
 
@@ -107,6 +109,20 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
           # can trigger an endless series of unload modals
           begin
             @browser.manage.delete_all_cookies
+            if options[:clear_session_storage]
+              if @browser.respond_to? :session_storage
+                @browser.session_storage.clear
+              else
+                warn "sessionStorage clear requested but is not available for this driver"
+              end
+            end
+            if options[:clear_local_storage]
+              if @browser.respond_to? :local_storage
+                @browser.local_storage.clear
+              else
+                warn "localStorage clear requested but is not available for this driver"
+              end
+            end
           rescue Selenium::WebDriver::Error::UnhandledError
             # delete_all_cookies fails when we've previously gone
             # to about:blank, so we rescue this error and do nothing

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -123,4 +123,8 @@ $(function() {
       input.disabled = true;
     }, 500)
   })
+  $('#set-storage').click(function(e){
+    sessionStorage.setItem('session', 'session_value');
+    localStorage.setItem('local', 'local value');
+  })
 });

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -97,7 +97,9 @@
     <p>
       <input id="disable-on-click"/>
     </p>
-
+    <p>
+      <input id="set-storage"/>
+    </p>
     <p>
       <a href="#" id="delayed-page-change">Change page</a>
       <a href="/with_html?options[]=things">Non-escaped query options</a>

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -8,6 +8,14 @@ Capybara.register_driver :selenium_chrome do |app|
   Capybara::Selenium::Driver.new(app, :browser => :chrome, :args => args)
 end
 
+Capybara.register_driver :selenium_chrome_clear_storage do |app|
+  args = ENV['TRAVIS'] ? ['no-sandbox' ] : []
+  Capybara::Selenium::Driver.new(app, :browser => :chrome,
+                                      :args => args,
+                                      clear_local_storage: true,
+                                      clear_session_storage: true)
+end
+
 module TestSessions
   Chrome = Capybara::Session.new(:selenium_chrome, TestApp)
 end
@@ -19,4 +27,28 @@ Capybara::SpecHelper.run_specs TestSessions::Chrome, "selenium_chrome", capybara
 
 RSpec.describe "Capybara::Session with chrome" do
   include_examples  "Capybara::Session", TestSessions::Chrome, :selenium_chrome
+
+  context "storage" do
+    describe "#reset!" do
+      it "does not clear either storage by default" do
+        @session = TestSessions::Chrome
+        @session.visit('/with_js')
+        @session.find(:css, '#set-storage').click
+        @session.reset!
+        @session.visit('/with_js')
+        expect(@session.driver.browser.local_storage.keys).not_to be_empty
+        expect(@session.driver.browser.session_storage.keys).not_to be_empty
+      end
+
+      it "clears storage when set" do
+        @session = Capybara::Session.new(:selenium_chrome_clear_storage, TestApp)
+        @session.visit('/with_js')
+        @session.find(:css, '#set-storage').click
+        @session.reset!
+        @session.visit('/with_js')
+        expect(@session.driver.browser.local_storage.keys).to be_empty
+        expect(@session.driver.browser.session_storage.keys).to be_empty
+      end
+    end
+  end
 end

--- a/spec/selenium_spec_firefox.rb
+++ b/spec/selenium_spec_firefox.rb
@@ -12,6 +12,16 @@ Capybara.register_driver :selenium_firefox do |app|
   )
 end
 
+Capybara.register_driver :selenium_firefox_cant_clear_storage do |app|
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :firefox,
+    desired_capabilities: Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false),
+    clear_local_storage: true,
+    clear_session_storage: true
+  )
+end
+
 module TestSessions
   Selenium = Capybara::Session.new(:selenium_firefox, TestApp)
 end
@@ -28,6 +38,16 @@ Capybara::SpecHelper.run_specs TestSessions::Selenium, "selenium", capybara_skip
 RSpec.describe "Capybara::Session with legacy firefox" do
   include_examples  "Capybara::Session", TestSessions::Selenium, :selenium_firefox
   include_examples  Capybara::RSpecMatchers, TestSessions::Selenium, :selenium_firefox
+
+  context "storage" do
+    it "warns storage clearing isn't available" do
+      @session = Capybara::Session.new(:selenium_firefox_cant_clear_storage, TestApp)
+      expect_any_instance_of(Kernel).to receive(:warn).with('sessionStorage clear requested but is not available for this driver')
+      expect_any_instance_of(Kernel).to receive(:warn).with('localStorage clear requested but is not available for this driver')
+      @session.visit('/')
+      @session.reset!
+    end
+  end
 end
 
 RSpec.describe Capybara::Selenium::Driver do


### PR DESCRIPTION
This adds setting to the selenium driver to trigger local/sessionStorage clearing during `#reset!`