### PR TITLE
Faster checking of checkbox by label

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -115,18 +115,17 @@ module Capybara
         locator, options = nil, locator if locator.is_a? Hash
         allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
 
-        begin
-          radio = find(:radio_button, locator, options)
-          radio.set(true)
-        rescue => e
-          raise unless allow_label_click && catch_error?(e)
+        radio = find(:radio_button, locator, options.merge({visible: (allow_label_click ? :all : true)}))
+
+        if !radio.visible? && allow_label_click
           begin
-            radio ||= find(:radio_button, locator, options.merge({wait: 0, visible: :all}))
             label = find(:label, for: radio, wait: 0, visible: true)
             label.click unless radio.checked?
           rescue
-            raise e
+            find(:radio_button, locator, options.merge({wait: 0})).set(true)
           end
+        else
+          radio.set(true)
         end
       end
 
@@ -149,22 +148,22 @@ module Capybara
       #   @macro waiting_behavior
       #
       # @return [Capybara::Node::Element]  The element checked or the label clicked
+
       def check(locator, options={})
         locator, options = nil, locator if locator.is_a? Hash
         allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
 
-        begin
-          cbox = find(:checkbox, locator, options)
-          cbox.set(true)
-        rescue => e
-          raise unless allow_label_click && catch_error?(e)
+        cbox = find(:checkbox, locator, options.merge({visible: (allow_label_click ? :all : true)}))
+
+        if !cbox.visible? && allow_label_click
           begin
-            cbox ||= find(:checkbox, locator, options.merge({wait: 0, visible: :all}))
             label = find(:label, for: cbox, wait: 0, visible: true)
             label.click unless cbox.checked?
           rescue
-            raise e
+            find(:checkbox, locator, options.merge({wait: 0})).set(true)
           end
+        else
+          cbox.set(true)
         end
       end
 
@@ -191,18 +190,17 @@ module Capybara
         locator, options = nil, locator if locator.is_a? Hash
         allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
 
-        begin
-          cbox = find(:checkbox, locator, options)
+        cbox = find(:checkbox, locator, options.merge({visible: (allow_label_click ? :all : true)}))
+
+        if !cbox.visible? && allow_label_click
+            begin
+              label = find(:label, for: cbox, wait: 0, visible: true)
+              label.click if cbox.checked?
+            rescue => e
+              find(:checkbox, locator, options.merge({wait: 0, visible: true})).set(false)
+            end
+        else
           cbox.set(false)
-        rescue => e
-          raise unless allow_label_click && catch_error?(e)
-          begin
-            cbox ||= find(:checkbox, locator, options.merge({wait: 0, visible: :all}))
-            label = find(:label, for: cbox, wait: 0, visible: true)
-            label.click if cbox.checked?
-          rescue
-            raise e
-          end
         end
       end
 


### PR DESCRIPTION
Speed up interactions with checkbox / radio where input is hidden but label is not by
* not waiting to find checkbox if not visible
* not waiting while trying to set value on checkout box `cbox.set` if not visible

Before this the default behaviour was to wait until the time out before checking if could interact via the label.