### PR TITLE
Make text option work when visible == :hidden

### DIFF
--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -53,7 +53,9 @@ module Capybara
       def matches_filters?(node)
         if options[:text]
           regexp = options[:text].is_a?(Regexp) ? options[:text] : Regexp.escape(options[:text].to_s)
-          return false if not node.text(visible).match(regexp)
+          text_visible = visible
+          text_visible = :all if text_visible == :hidden
+          return false if not node.text(text_visible).match(regexp)
         end
 
         case visible

--- a/lib/capybara/spec/session/first_spec.rb
+++ b/lib/capybara/spec/session/first_spec.rb
@@ -48,21 +48,26 @@ Capybara::SpecHelper.spec '#first' do
 
     it "should find nodes regardless of whether they are invisible when false" do
       expect(@session.first(:css, "a#invisible", visible: false)).not_to be_nil
+      expect(@session.first(:css, "a#invisible", visible: false, text: 'hidden link')).not_to be_nil
       expect(@session.first(:css, "a#visible", visible: false)).not_to be_nil
     end
 
     it "should find nodes regardless of whether they are invisible when :all" do
       expect(@session.first(:css, "a#invisible", visible: :all)).not_to be_nil
+      expect(@session.first(:css, "a#invisible", visible: :all, text: 'hidden link')).not_to be_nil
       expect(@session.first(:css, "a#visible", visible: :all)).not_to be_nil
     end
 
     it "should find only hidden nodes when :hidden" do
       expect(@session.first(:css, "a#invisible", visible: :hidden)).not_to be_nil
+      expect(@session.first(:css, "a#invisible", visible: :hidden, text: 'hidden link')).not_to be_nil
+      expect(@session.first(:css, "a#invisible", visible: :hidden, text: 'not hidden link')).to be_nil
       expect(@session.first(:css, "a#visible", visible: :hidden)).to be_nil
     end
 
     it "should find only visible nodes when :visible" do
       expect(@session.first(:css, "a#invisible", visible: :visible)).to be_nil
+      expect(@session.first(:css, "a#invisible", visible: :visible, text: 'hidden link')).to be_nil
       expect(@session.first(:css, "a#visible", visible: :visible)).not_to be_nil
     end
 

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -429,7 +429,7 @@ Capybara::SpecHelper.spec "node" do
       end
     end
 
-    it "sets an explanatory exception as the cause of server exceptions with errors with initializers", requires: [:server, :js], twtw: true do
+    it "sets an explanatory exception as the cause of server exceptions with errors with initializers", requires: [:server, :js] do
       skip "This version of ruby doesn't support exception causes" unless Exception.instance_methods.include? :cause
       quietly { @session.visit("/other_error") }
       expect do


### PR DESCRIPTION
There is currently an issue where if you use the text option combined with visible: :hidden option in a selector the text will never match.  This fixes that